### PR TITLE
Add automatic GitHub repo setup to installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,8 @@ claude-sync push
 
 ### First machine (where your config already lives)
 
-```bash
-# The installer handles everything — init, repo creation, and first push.
-# If you installed manually, see the manual steps above.
-```
+The one-liner installer handles everything — init, repo creation, and first push.
+If you installed manually, see the manual steps above.
 
 ### Every other machine
 

--- a/install.sh
+++ b/install.sh
@@ -152,6 +152,13 @@ if [ -z "$GH_USER" ]; then
 fi
 
 REPO_NAME=$(prompt "Repository name" "$DEFAULT_REPO_NAME")
+
+# Sanitize repo name: lowercase, replace spaces/special chars with hyphens, strip leading/trailing hyphens
+REPO_NAME=$(echo "$REPO_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g; s/^-*//; s/-*$//')
+if [ -z "$REPO_NAME" ]; then
+  REPO_NAME="$DEFAULT_REPO_NAME"
+fi
+
 REPO_VISIBILITY=$(prompt "Visibility (private/public)" "private")
 
 # Validate visibility
@@ -164,12 +171,15 @@ esac
 echo ""
 info "Creating $REPO_VISIBILITY repo: $GH_USER/$REPO_NAME"
 
-if gh repo create "$REPO_NAME" --"$REPO_VISIBILITY" --description "Claude Code config synced by claude-sync" 2>/dev/null; then
+GH_CREATE_OUTPUT=$(gh repo create "$REPO_NAME" --"$REPO_VISIBILITY" --description "Claude Code config synced by claude-sync" 2>&1) && {
   ok "GitHub repo created"
-else
-  # Repo may already exist — that's fine, we'll try to use it
-  warn "Could not create repo (may already exist). Continuing..."
-fi
+} || {
+  if echo "$GH_CREATE_OUTPUT" | grep -qi "already exists"; then
+    warn "Repository $GH_USER/$REPO_NAME already exists. Continuing..."
+  else
+    err "Failed to create repo: $GH_CREATE_OUTPUT"
+  fi
+}
 
 REMOTE_URL="git@github.com:$GH_USER/$REPO_NAME.git"
 


### PR DESCRIPTION
## Summary
- After installing the CLI, the installer now prompts for a GitHub repo name (default: `claude-config`) and visibility (default: `private`)
- Automatically creates the repo via `gh`, runs `claude-sync init`, adds the remote, and pushes
- Gracefully degrades: no `gh` → manual instructions, no auth → manual instructions, no tty → uses defaults, existing sync repo → skips setup
- Uses `/dev/tty` for stdin so prompts work with `curl | bash`
- Updates README to reflect the streamlined one-command setup

## Test plan
- [ ] Run installer with `gh` authenticated — verify repo creation, init, and push succeed
- [ ] Run installer without `gh` installed — verify graceful fallback with manual instructions
- [ ] Run installer when `~/.claude-sync` already exists — verify it skips setup
- [ ] Run installer when `~/.claude` doesn't exist — verify warning message
- [ ] Run installer with `gh` installed but not authenticated — verify fallback
- [ ] Run installer in headless environment (no `/dev/tty`) — verify defaults are used
- [ ] Enter invalid visibility (e.g. "foo") — verify it falls back to "private"
- [ ] Enter repo name that already exists on GitHub — verify "may already exist" warning and continuation

🤖 Generated with [Claude Code](https://claude.com/claude-code)