### PR TITLE
feat: auto-detect installed environments

### DIFF
--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -1,6 +1,11 @@
 import type { Command } from "commander";
 import pc from "picocolors";
-import { getEnabledEnvironments, setEnabledEnvironments } from "../../core/env-config.js";
+import {
+	getEnabledEnvironments,
+	isAutoDetecting,
+	resetEnvironmentConfig,
+	setEnabledEnvironments,
+} from "../../core/env-config.js";
 import { ALL_ENVIRONMENTS, getEnvironmentById } from "../../core/environment.js";
 
 /**
@@ -13,6 +18,13 @@ export function registerEnvCommand(program: Command): void {
 		.command("list")
 		.description("Show all environments and their enabled status")
 		.action(() => {
+			const auto = isAutoDetecting();
+			if (auto) {
+				console.log(pc.dim("  Mode: auto-detect (syncing every installed tool)"));
+			} else {
+				console.log(pc.dim("  Mode: manual (run 'ai-sync env reset' to re-enable auto-detect)"));
+			}
+			console.log();
 			const enabled = new Set(getEnabledEnvironments());
 			for (const env of ALL_ENVIRONMENTS) {
 				const status = enabled.has(env.id) ? pc.green("enabled") : pc.dim("disabled");
@@ -66,5 +78,15 @@ export function registerEnvCommand(program: Command): void {
 			}
 			setEnabledEnvironments(updated);
 			console.log(pc.green(`Disabled ${env.displayName}`));
+		});
+
+	envCmd
+		.command("reset")
+		.description("Switch back to auto-detection (sync every installed tool)")
+		.action(() => {
+			resetEnvironmentConfig();
+			const detected = getEnabledEnvironments();
+			console.log(pc.green("Switched to auto-detect mode"));
+			console.log(pc.dim(`  Detected environments: ${detected.join(", ")}`));
 		});
 }

--- a/src/core/env-config.ts
+++ b/src/core/env-config.ts
@@ -10,8 +10,31 @@ function getConfigPath(): string {
 }
 
 /**
+ * Auto-detect which environments are installed by checking whether
+ * their config directories exist on disk.  Falls back to ["claude"]
+ * if none are found (e.g. fresh machine before any tool has run).
+ */
+function detectInstalledEnvironments(): string[] {
+	const detected: string[] = [];
+	for (const env of ALL_ENVIRONMENTS) {
+		try {
+			fs.accessSync(env.getConfigDir());
+			detected.push(env.id);
+		} catch {
+			// Config dir doesn't exist — tool not installed
+		}
+	}
+	return detected.length > 0 ? detected : ["claude"];
+}
+
+/**
  * Returns the list of enabled environment IDs.
- * Defaults to ["claude"] if no config file exists.
+ *
+ * If the user has explicitly configured environments (via `env enable`
+ * or `env disable`), the stored list is used.  Otherwise, environments
+ * are auto-detected by checking which tools have config directories on
+ * disk.  This means a fresh install automatically syncs every tool
+ * that is present — no manual `env enable` required.
  */
 export function getEnabledEnvironments(): string[] {
 	try {
@@ -21,9 +44,9 @@ export function getEnabledEnvironments(): string[] {
 			return parsed;
 		}
 	} catch {
-		// No file or parse error — default to claude only
+		// No file or parse error — fall through to auto-detection
 	}
-	return ["claude"];
+	return detectInstalledEnvironments();
 }
 
 /**
@@ -43,6 +66,30 @@ export function setEnabledEnvironments(ids: string[]): void {
 	const configPath = getConfigPath();
 	fs.mkdirSync(path.dirname(configPath), { recursive: true });
 	fs.writeFileSync(configPath, JSON.stringify(ids, null, 2) + "\n");
+}
+
+/**
+ * Returns true when environments are auto-detected (no explicit config file).
+ */
+export function isAutoDetecting(): boolean {
+	try {
+		fs.accessSync(getConfigPath());
+		return false;
+	} catch {
+		return true;
+	}
+}
+
+/**
+ * Removes the explicit environment config file so that environments
+ * are auto-detected again on the next operation.
+ */
+export function resetEnvironmentConfig(): void {
+	try {
+		fs.unlinkSync(getConfigPath());
+	} catch {
+		// Already absent — nothing to do
+	}
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ export { createBackup } from "./core/backup.js";
 export {
 	getEnabledEnvironmentInstances,
 	getEnabledEnvironments,
+	isAutoDetecting,
+	resetEnvironmentConfig,
 	setEnabledEnvironments,
 } from "./core/env-config.js";
 export { makeAllowlistFn, needsPathRewrite } from "./core/env-helpers.js";

--- a/tests/commands/env.test.ts
+++ b/tests/commands/env.test.ts
@@ -13,7 +13,12 @@ vi.mock("../../src/platform/paths.js", async (importOriginal) => {
 
 let testInstallDir: string;
 
-import { getEnabledEnvironments, setEnabledEnvironments } from "../../src/core/env-config.js";
+import {
+	getEnabledEnvironments,
+	isAutoDetecting,
+	resetEnvironmentConfig,
+	setEnabledEnvironments,
+} from "../../src/core/env-config.js";
 import { ALL_ENVIRONMENTS, getEnvironmentById } from "../../src/core/environment.js";
 
 describe("env command logic", () => {
@@ -42,11 +47,12 @@ describe("env command logic", () => {
 	});
 
 	describe("env enable", () => {
-		it("enables a new environment", () => {
-			const initial = getEnabledEnvironments();
-			expect(initial).toEqual(["claude"]);
+		it("enables a new environment explicitly", () => {
+			// Start with explicit config so we control the baseline
+			setEnabledEnvironments(["claude"]);
+			expect(getEnabledEnvironments()).toEqual(["claude"]);
 
-			setEnabledEnvironments([...initial, "opencode"]);
+			setEnabledEnvironments(["claude", "opencode"]);
 			expect(getEnabledEnvironments()).toEqual(["claude", "opencode"]);
 		});
 
@@ -71,6 +77,18 @@ describe("env command logic", () => {
 
 		it("cannot disable all environments", () => {
 			expect(() => setEnabledEnvironments([])).toThrow(/at least one environment/i);
+		});
+	});
+
+	describe("env reset", () => {
+		it("removes config and switches back to auto-detect", () => {
+			setEnabledEnvironments(["claude"]);
+			expect(isAutoDetecting()).toBe(false);
+
+			resetEnvironmentConfig();
+			expect(isAutoDetecting()).toBe(true);
+			// Auto-detect should find at least claude
+			expect(getEnabledEnvironments()).toContain("claude");
 		});
 	});
 

--- a/tests/core/env-config.test.ts
+++ b/tests/core/env-config.test.ts
@@ -17,6 +17,8 @@ let testInstallDir: string;
 import {
 	getEnabledEnvironmentInstances,
 	getEnabledEnvironments,
+	isAutoDetecting,
+	resetEnvironmentConfig,
 	setEnabledEnvironments,
 } from "../../src/core/env-config.js";
 
@@ -30,9 +32,13 @@ describe("env-config", () => {
 	});
 
 	describe("getEnabledEnvironments", () => {
-		it("defaults to ['claude'] when no config file exists", () => {
+		it("auto-detects installed environments when no config file exists", () => {
 			const result = getEnabledEnvironments();
-			expect(result).toEqual(["claude"]);
+			// Should contain at least "claude" (since ~/.claude exists on dev machines)
+			// and may contain "opencode" if installed.  The key point is that it
+			// doesn't return an empty list and every id is a known environment.
+			expect(result.length).toBeGreaterThanOrEqual(1);
+			expect(result).toContain("claude");
 		});
 
 		it("reads environments from config file", () => {
@@ -44,16 +50,18 @@ describe("env-config", () => {
 			expect(result).toEqual(["claude", "opencode"]);
 		});
 
-		it("defaults to ['claude'] if config file is malformed", () => {
+		it("falls back to auto-detect if config file is malformed", () => {
 			fs.writeFileSync(path.join(testInstallDir, ".environments.json"), "not valid json");
 			const result = getEnabledEnvironments();
-			expect(result).toEqual(["claude"]);
+			expect(result.length).toBeGreaterThanOrEqual(1);
+			expect(result).toContain("claude");
 		});
 
-		it("defaults to ['claude'] if config contains non-strings", () => {
+		it("falls back to auto-detect if config contains non-strings", () => {
 			fs.writeFileSync(path.join(testInstallDir, ".environments.json"), JSON.stringify([1, 2, 3]));
 			const result = getEnabledEnvironments();
-			expect(result).toEqual(["claude"]);
+			expect(result.length).toBeGreaterThanOrEqual(1);
+			expect(result).toContain("claude");
 		});
 	});
 
@@ -70,6 +78,30 @@ describe("env-config", () => {
 
 		it("throws when trying to set empty array", () => {
 			expect(() => setEnabledEnvironments([])).toThrow(/at least one environment/i);
+		});
+	});
+
+	describe("isAutoDetecting", () => {
+		it("returns true when no config file exists", () => {
+			expect(isAutoDetecting()).toBe(true);
+		});
+
+		it("returns false after setEnabledEnvironments is called", () => {
+			setEnabledEnvironments(["claude"]);
+			expect(isAutoDetecting()).toBe(false);
+		});
+	});
+
+	describe("resetEnvironmentConfig", () => {
+		it("removes config file and restores auto-detect", () => {
+			setEnabledEnvironments(["claude"]);
+			expect(isAutoDetecting()).toBe(false);
+			resetEnvironmentConfig();
+			expect(isAutoDetecting()).toBe(true);
+		});
+
+		it("is safe to call when no config file exists", () => {
+			expect(() => resetEnvironmentConfig()).not.toThrow();
 		});
 	});
 


### PR DESCRIPTION
## Summary
- **Auto-detection**: When no `.environments.json` exists, ai-sync checks which tools have config directories on disk (`~/.claude`, `~/.config/opencode`) and syncs all installed ones automatically
- **Zero config**: Users no longer need `ai-sync env enable opencode` — if it's installed, it syncs
- **`env reset`**: New command to switch back to auto-detect after any manual `enable`/`disable`
- **`env list`**: Now shows whether mode is "auto-detect" or "manual"
- Explicit `env enable` / `env disable` still works and pins the config

## Test plan
- [x] All 189 tests pass (5 new tests for auto-detect, reset, isAutoDetecting)
- [ ] Manual: fresh install with both tools → `ai-sync env list` shows both enabled
- [ ] Manual: `ai-sync env disable opencode` → pins config, only claude synced
- [ ] Manual: `ai-sync env reset` → back to auto-detect

🤖 Generated with [Claude Code](https://claude.com/claude-code)