### PR TITLE
fix: sync skills and plugin metadata

### DIFF
--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -45,11 +45,17 @@ export class ClaudeEnvironment implements Environment {
 			"get-shit-done/",
 			"package.json",
 			"gsd-file-manifest.json",
+			"skills/",
 		];
 	}
 
 	getPluginSyncPatterns(): readonly string[] {
-		return ["plugins/blocklist.json", "plugins/known_marketplaces.json", "plugins/marketplaces/"];
+		return [
+			"plugins/blocklist.json",
+			"plugins/known_marketplaces.json",
+			"plugins/marketplaces/",
+			"plugins/installed_plugins.json",
+		];
 	}
 
 	getIgnorePatterns(): readonly string[] {
@@ -57,7 +63,7 @@ export class ClaudeEnvironment implements Environment {
 	}
 
 	getPathRewriteTargets(): string[] {
-		return ["settings.json"];
+		return ["settings.json", "installed_plugins.json"];
 	}
 
 	getSkillsSubdir(): string | null {

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -12,6 +12,7 @@ export const DEFAULT_SYNC_TARGETS: readonly string[] = [
 	"get-shit-done/",
 	"package.json",
 	"gsd-file-manifest.json",
+	"skills/",
 ] as const;
 
 /**
@@ -22,6 +23,7 @@ export const PLUGIN_SYNC_PATTERNS: readonly string[] = [
 	"plugins/blocklist.json",
 	"plugins/known_marketplaces.json",
 	"plugins/marketplaces/",
+	"plugins/installed_plugins.json",
 ] as const;
 
 /**

--- a/tests/core/environment.test.ts
+++ b/tests/core/environment.test.ts
@@ -36,8 +36,16 @@ describe("environment", () => {
 			expect(claude.getSyncTargets()).toContain("commands/");
 		});
 
+		it("has skills/ as sync target", () => {
+			expect(claude.getSyncTargets()).toContain("skills/");
+		});
+
 		it("has plugin sync patterns", () => {
 			expect(claude.getPluginSyncPatterns().length).toBeGreaterThan(0);
+		});
+
+		it("has installed_plugins.json in plugin sync patterns", () => {
+			expect(claude.getPluginSyncPatterns()).toContain("plugins/installed_plugins.json");
 		});
 
 		it("has plugin ignore patterns", () => {
@@ -46,6 +54,10 @@ describe("environment", () => {
 
 		it("path rewrite targets include settings.json", () => {
 			expect(claude.getPathRewriteTargets()).toContain("settings.json");
+		});
+
+		it("path rewrite targets include installed_plugins.json", () => {
+			expect(claude.getPathRewriteTargets()).toContain("installed_plugins.json");
 		});
 
 		it("skills subdir is 'commands'", () => {

--- a/tests/core/manifest.test.ts
+++ b/tests/core/manifest.test.ts
@@ -8,8 +8,8 @@ import {
 
 describe("manifest", () => {
 	describe("DEFAULT_SYNC_TARGETS", () => {
-		it("contains exactly 8 sync targets", () => {
-			expect(DEFAULT_SYNC_TARGETS).toHaveLength(8);
+		it("contains exactly 9 sync targets", () => {
+			expect(DEFAULT_SYNC_TARGETS).toHaveLength(9);
 		});
 
 		it("contains the expected sync targets", () => {
@@ -22,14 +22,15 @@ describe("manifest", () => {
 				"get-shit-done/",
 				"package.json",
 				"gsd-file-manifest.json",
+				"skills/",
 			];
 			expect([...DEFAULT_SYNC_TARGETS].sort()).toEqual([...expected].sort());
 		});
 	});
 
 	describe("PLUGIN_SYNC_PATTERNS", () => {
-		it("contains 3 plugin sync patterns", () => {
-			expect(PLUGIN_SYNC_PATTERNS).toHaveLength(3);
+		it("contains 4 plugin sync patterns", () => {
+			expect(PLUGIN_SYNC_PATTERNS).toHaveLength(4);
 		});
 
 		it("contains the expected plugin sync patterns", () => {
@@ -37,6 +38,7 @@ describe("manifest", () => {
 				"plugins/blocklist.json",
 				"plugins/known_marketplaces.json",
 				"plugins/marketplaces/",
+				"plugins/installed_plugins.json",
 			];
 			expect([...PLUGIN_SYNC_PATTERNS].sort()).toEqual([...expected].sort());
 		});
@@ -59,6 +61,14 @@ describe("manifest", () => {
 
 		it("allows nested files under allowed directories", () => {
 			expect(isPathAllowed("agents/my-skill/SKILL.md")).toBe(true);
+		});
+
+		it("allows files under skills/ directory", () => {
+			expect(isPathAllowed("skills/autoresearch/SKILL.md")).toBe(true);
+		});
+
+		it("allows plugins/installed_plugins.json", () => {
+			expect(isPathAllowed("plugins/installed_plugins.json")).toBe(true);
 		});
 
 		it("rejects files in projects/ directory", () => {


### PR DESCRIPTION
## Summary
- Add `skills/` to sync targets so superpower skills are synchronized across machines
- Add `plugins/installed_plugins.json` to plugin sync patterns so plugin installation metadata is shared
- Add path rewriting for `installed_plugins.json` (contains absolute `installPath` values needing `{{HOME}}` tokenization)

## Test plan
- [x] All existing tests pass
- [x] New test cases for `skills/` allowlist, `installed_plugins.json` allowlist, and path rewrite target
- [x] Typecheck passes
- [x] Lint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)