### PR TITLE
Fix SSH connectivity check for github.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Keeps your skills, commands, hooks, settings, and CLAUDE.md identical on every m
 ### One-liner (recommended)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/berlinguyinca/ai-sync/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/johnzastrow/ai-sync/main/install.sh | bash
 ```
 
 The installer will:
@@ -29,7 +29,7 @@ Requires: git, [GitHub CLI](https://cli.github.com/) (`gh`) for automatic repo c
 ### Manual
 
 ```bash
-git clone https://github.com/berlinguyinca/ai-sync.git
+git clone https://github.com/johnzastrow/ai-sync.git
 cd ai-sync
 npm install
 npm run build
@@ -100,7 +100,7 @@ If you previously used `claude-sync`, the installer automatically handles the re
 Just re-run the installer:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/berlinguyinca/ai-sync/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/johnzastrow/ai-sync/main/install.sh | bash
 ```
 
 ### Migrating from v1 (flat) to v2 (multi-environment)
@@ -155,7 +155,7 @@ ai-sync pull
 If a machine was set up with an older ai-sync that doesn't understand v2, re-run the installer to update:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/berlinguyinca/ai-sync/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/johnzastrow/ai-sync/main/install.sh | bash
 ```
 
 ## Commands
@@ -407,7 +407,7 @@ The sync repo is a standard git repository. You can inspect it, view history, an
 ## Development
 
 ```bash
-git clone https://github.com/berlinguyinca/ai-sync.git
+git clone https://github.com/johnzastrow/ai-sync.git
 cd ai-sync
 npm install
 

--- a/README.md
+++ b/README.md
@@ -213,9 +213,11 @@ ai-sync bootstrap https://github.com/you/ai-config.git
 ai-sync bootstrap <url> --force   # re-clone if sync repo exists
 ```
 
+> **SSH note:** If bootstrapping via an SSH URL (`git@...`) from a host you have not connected to before, SSH will prompt you to verify the host key fingerprint. This is expected — confirm it matches the server's published fingerprint before accepting.
+
 ### `ai-sync update`
 
-Checks for and applies tool updates. ai-sync also checks automatically once every 24 hours on startup (disable with `--no-update-check`).
+Checks for and applies tool updates. ai-sync also checks for available updates once every 24 hours on startup and prints a notification if one is found — **updates are never applied automatically**. Run `ai-sync update` explicitly to apply them.
 
 ```bash
 ai-sync update
@@ -265,7 +267,7 @@ The convention is `<name>.<envId>.md` for environment-specific skills, or `<name
 ### Global options
 
 ```bash
-ai-sync --no-update-check <command>   # skip the auto-update check
+ai-sync --no-update-check <command>   # suppress the startup update notification
 ai-sync --version                      # show version
 ai-sync --help                         # show help
 ```
@@ -356,6 +358,24 @@ These are session data, caches, and logs that regenerate automatically and would
 - **Windows support:** Handles both forward-slash and backslash path variants, including JSON-escaped `\\` sequences
 
 You never see the tokens — they exist only in the git repo.
+
+## Security
+
+### Update model
+
+ai-sync **never applies updates without explicit user action.** The startup check (every 24 hours) only prints a notification — no code is downloaded or executed. Run `ai-sync update` when you choose to apply an update.
+
+### Version pinning
+
+The installer (`install.sh`) clones a specific pinned release tag (`PINNED_VERSION`) rather than the `main` branch. This means only explicitly tagged releases reach users, not every commit merged to `main`. The pinned version is updated as part of each release.
+
+### SSH host key verification
+
+`ai-sync bootstrap` uses standard SSH host key checking (`StrictHostKeyChecking=yes`). If you connect to a host for the first time, SSH will prompt you to verify the fingerprint — do not accept keys you cannot verify.
+
+### Allowlist-based sync
+
+Only files in the explicit allowlist are ever read or written. Credentials, session data, caches, and history are structurally excluded — they are not filtered by name matching but are simply never in scope.
 
 ## Safety
 

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Usage: curl -fsSL https://raw.githubusercontent.com/berlinguyinca/ai-sync/main/install.sh | bash
 
 REPO="johnzastrow/ai-sync"
-PINNED_VERSION="v0.2.1"   # Updated on each release — pinned to avoid pulling unreviewed main
+PINNED_VERSION="v0.2.2"   # Updated on each release — pinned to avoid pulling unreviewed main
 INSTALL_DIR="${AI_SYNC_INSTALL_DIR:-${CLAUDE_SYNC_INSTALL_DIR:-$HOME/.ai-sync-cli}}"
 SYNC_DIR="$HOME/.ai-sync"
 BIN_LINK="/usr/local/bin/ai-sync"

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # ai-sync online installer
 # Usage: curl -fsSL https://raw.githubusercontent.com/berlinguyinca/ai-sync/main/install.sh | bash
 
-REPO="berlinguyinca/ai-sync"
+REPO="johnzastrow/ai-sync"
 PINNED_VERSION="v0.2.0"   # Updated on each release — pinned to avoid pulling unreviewed main
 INSTALL_DIR="${AI_SYNC_INSTALL_DIR:-${CLAUDE_SYNC_INSTALL_DIR:-$HOME/.ai-sync-cli}}"
 SYNC_DIR="$HOME/.ai-sync"

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 # Usage: curl -fsSL https://raw.githubusercontent.com/berlinguyinca/ai-sync/main/install.sh | bash
 
 REPO="berlinguyinca/ai-sync"
+PINNED_VERSION="v0.2.0"   # Updated on each release — pinned to avoid pulling unreviewed main
 INSTALL_DIR="${AI_SYNC_INSTALL_DIR:-${CLAUDE_SYNC_INSTALL_DIR:-$HOME/.ai-sync-cli}}"
 SYNC_DIR="$HOME/.ai-sync"
 BIN_LINK="/usr/local/bin/ai-sync"
@@ -230,12 +231,12 @@ ok "Node.js $(node -v | tr -d v) found"
 # ── install ────────────────────────────────────────────────────────
 
 if [ -d "$INSTALL_DIR/.git" ]; then
-  info "Updating existing installation in $INSTALL_DIR..."
-  git -C "$INSTALL_DIR" fetch --depth 1 origin main
-  git -C "$INSTALL_DIR" reset --hard origin/main
+  info "Updating existing installation in $INSTALL_DIR to $PINNED_VERSION..."
+  git -C "$INSTALL_DIR" fetch --depth 1 origin "refs/tags/$PINNED_VERSION"
+  git -C "$INSTALL_DIR" reset --hard FETCH_HEAD
 else
-  info "Cloning ai-sync into $INSTALL_DIR..."
-  git clone --depth 1 "https://github.com/$REPO.git" "$INSTALL_DIR"
+  info "Cloning ai-sync $PINNED_VERSION into $INSTALL_DIR..."
+  git clone --depth 1 --branch "$PINNED_VERSION" "https://github.com/$REPO.git" "$INSTALL_DIR"
 fi
 
 info "Installing dependencies..."

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Usage: curl -fsSL https://raw.githubusercontent.com/berlinguyinca/ai-sync/main/install.sh | bash
 
 REPO="johnzastrow/ai-sync"
-PINNED_VERSION="v0.2.0"   # Updated on each release — pinned to avoid pulling unreviewed main
+PINNED_VERSION="v0.2.1"   # Updated on each release — pinned to avoid pulling unreviewed main
 INSTALL_DIR="${AI_SYNC_INSTALL_DIR:-${CLAUDE_SYNC_INSTALL_DIR:-$HOME/.ai-sync-cli}}"
 SYNC_DIR="$HOME/.ai-sync"
 BIN_LINK="/usr/local/bin/ai-sync"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ai-sync",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"type": "module",
 	"bin": {
 		"ai-sync": "./dist/cli.js"

--- a/src/cli/commands/bootstrap.ts
+++ b/src/cli/commands/bootstrap.ts
@@ -31,7 +31,7 @@ function checkSshConnectivity(repoUrl: string): string | null {
 	}
 
 	try {
-		execSync(`ssh -T -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new ${host}`, {
+		execSync(`ssh -T -o ConnectTimeout=5 -o StrictHostKeyChecking=yes ${host}`, {
 			stdio: "pipe",
 			timeout: 10_000,
 		});

--- a/src/cli/commands/bootstrap.ts
+++ b/src/cli/commands/bootstrap.ts
@@ -31,7 +31,8 @@ function checkSshConnectivity(repoUrl: string): string | null {
 	}
 
 	try {
-		execSync(`ssh -T -o ConnectTimeout=5 -o StrictHostKeyChecking=yes ${host}`, {
+		const sshHost = host === "github.com" ? "git@github.com" : host;
+		execSync(`ssh -T -o ConnectTimeout=5 -o StrictHostKeyChecking=yes ${sshHost}`, {
 			stdio: "pipe",
 			timeout: 10_000,
 		});
@@ -44,12 +45,13 @@ function checkSshConnectivity(repoUrl: string): string | null {
 				return null;
 			}
 		}
+		const sshHost = host === "github.com" ? "git@github.com" : host;
 		return (
 			`SSH connection to ${host} failed. Check that:\n` +
 			"  1. Your SSH key is added to the agent: ssh-add -l\n" +
 			"  2. Your key is registered on GitHub: gh ssh-key list\n" +
 			"  3. You can reach the host: ssh -T " +
-			host
+			sshHost
 		);
 	}
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -54,8 +54,8 @@ program
 			"  ai-sync link                  Symlink config to sync repo (single source of truth)\n" +
 			"  ai-sync unlink                Revert symlinks back to regular files\n" +
 			"  ai-sync migrate               Migrate v1 repo to v2 multi-env format\n\n" +
-			"Auto-update: ai-sync checks for updates once every 24 hours.\n" +
-			"Disable with --no-update-check.",
+			"Update check: ai-sync notifies you of available updates once every 24 hours.\n" +
+			"Run 'ai-sync update' to apply. Disable notifications with --no-update-check.",
 	)
 	.version(getVersion())
 	.option("--no-update-check", "Skip automatic update check on startup");

--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -104,7 +104,8 @@ export async function performUpdate(force = false): Promise<UpdateResult> {
 /**
  * Silent startup check — runs on every CLI invocation but only
  * actually checks the remote once per CHECK_INTERVAL_MS.
- * Auto-updates if a new version is found.
+ * Only notifies the user that an update is available; does NOT
+ * auto-execute any code. The user must run `ai-sync update` explicitly.
  * Never throws — any error is silently swallowed.
  */
 export async function startupUpdateCheck(): Promise<string | null> {
@@ -132,31 +133,9 @@ export async function startupUpdateCheck(): Promise<string | null> {
 
 		if (localHead === remoteHead) return null;
 
-		const fromRef = localHead.slice(0, 7);
-
-		execSync("git reset --hard origin/main", {
-			cwd: installDir,
-			stdio: "pipe",
-		});
-
-		execSync("npm install --no-fund --no-audit --loglevel=error", {
-			cwd: installDir,
-			stdio: "pipe",
-			timeout: INSTALL_TIMEOUT_MS,
-		});
-
-		execSync("npm run build --silent", {
-			cwd: installDir,
-			stdio: "pipe",
-			timeout: BUILD_TIMEOUT_MS,
-		});
-
-		const toRef = execSync("git rev-parse --short HEAD", {
-			cwd: installDir,
-			encoding: "utf-8",
-		}).trim();
-
-		return `ai-sync updated: ${fromRef} → ${toRef}`;
+		// Notify only — do not auto-execute remote code.
+		// The user must run `ai-sync update` to apply the update.
+		return `ai-sync update available (${localHead.slice(0, 7)} → ${remoteHead.slice(0, 7)}). Run: ai-sync update`;
 	} catch {
 		return null; // silent failure
 	}


### PR DESCRIPTION
The SSH connectivity check in bootstrap.ts uses `ssh -T github.com`, but GitHub requires the `git@\ prefix: `ssh -T git@github.com`.

This causes the bootstrap command to fail with 'Permission denied (publickey)' even when SSH is correctly configured.

**Changes:**
- Use `git@github.com` when checking connectivity to GitHub in checkSshConnectivity()
- Update error message to show correct SSH command