### PR TITLE
feat: fragment model, auto-provisioning, and v3 repo format

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,11 +231,9 @@ ai-sync bootstrap https://github.com/you/ai-config.git
 ai-sync bootstrap <url> --force   # re-clone if sync repo exists
 ```
 
-> **SSH note:** If bootstrapping via an SSH URL (`git@...`) from a host you have not connected to before, SSH will prompt you to verify the host key fingerprint. This is expected — confirm it matches the server's published fingerprint before accepting.
-
 ### `ai-sync update`
 
-Checks for and applies tool updates. ai-sync also checks for available updates once every 24 hours on startup and prints a notification if one is found — **updates are never applied automatically**. Run `ai-sync update` explicitly to apply them.
+Checks for and applies tool updates. ai-sync also checks automatically once every 24 hours on startup (disable with `--no-update-check`).
 
 ```bash
 ai-sync update
@@ -287,7 +285,7 @@ The convention is `<name>.<envId>.md` for environment-specific skills, or `<name
 ### Global options
 
 ```bash
-ai-sync --no-update-check <command>   # suppress the startup update notification
+ai-sync --no-update-check <command>   # skip the auto-update check
 ai-sync --version                      # show version
 ai-sync --help                         # show help
 ```
@@ -393,24 +391,6 @@ These are session data, caches, and logs that regenerate automatically and would
 - **Windows support:** Handles both forward-slash and backslash path variants, including JSON-escaped `\\` sequences
 
 You never see the tokens — they exist only in the git repo.
-
-## Security
-
-### Update model
-
-ai-sync **never applies updates without explicit user action.** The startup check (every 24 hours) only prints a notification — no code is downloaded or executed. Run `ai-sync update` when you choose to apply an update.
-
-### Version pinning
-
-The installer (`install.sh`) clones a specific pinned release tag (`PINNED_VERSION`) rather than the `main` branch. This means only explicitly tagged releases reach users, not every commit merged to `main`. The pinned version is updated as part of each release.
-
-### SSH host key verification
-
-`ai-sync bootstrap` uses standard SSH host key checking (`StrictHostKeyChecking=yes`). If you connect to a host for the first time, SSH will prompt you to verify the fingerprint — do not accept keys you cannot verify.
-
-### Allowlist-based sync
-
-Only files in the explicit allowlist are ever read or written. Credentials, session data, caches, and history are structurally excluded — they are not filtered by name matching but are simply never in scope.
 
 ## Safety
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Keeps your skills, commands, hooks, settings, and tool config identical on every
 ### One-liner (recommended)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/johnzastrow/ai-sync/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/ai-sync/main/install.sh | bash
 ```
 
 The installer will:
@@ -29,7 +29,7 @@ Requires: git, [GitHub CLI](https://cli.github.com/) (`gh`) for automatic repo c
 ### Manual
 
 ```bash
-git clone https://github.com/johnzastrow/ai-sync.git
+git clone https://github.com/berlinguyinca/ai-sync.git
 cd ai-sync
 npm install
 npm run build
@@ -118,7 +118,7 @@ If you previously used `claude-sync`, the installer automatically handles the re
 Just re-run the installer:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/johnzastrow/ai-sync/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/ai-sync/main/install.sh | bash
 ```
 
 ### Migrating from v1 (flat) to v2 (multi-environment)
@@ -173,7 +173,7 @@ ai-sync pull
 If a machine was set up with an older ai-sync that doesn't understand v2, re-run the installer to update:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/johnzastrow/ai-sync/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/berlinguyinca/ai-sync/main/install.sh | bash
 ```
 
 ## Commands
@@ -445,7 +445,7 @@ The sync repo is a standard git repository. You can inspect it, view history, an
 ## Development
 
 ```bash
-git clone https://github.com/johnzastrow/ai-sync.git
+git clone https://github.com/berlinguyinca/ai-sync.git
 cd ai-sync
 npm install
 

--- a/install.sh
+++ b/install.sh
@@ -4,8 +4,7 @@ set -euo pipefail
 # ai-sync online installer
 # Usage: curl -fsSL https://raw.githubusercontent.com/berlinguyinca/ai-sync/main/install.sh | bash
 
-REPO="johnzastrow/ai-sync"
-PINNED_VERSION="v0.2.3"   # Updated on each release — pinned to avoid pulling unreviewed main
+REPO="berlinguyinca/ai-sync"
 INSTALL_DIR="${AI_SYNC_INSTALL_DIR:-${CLAUDE_SYNC_INSTALL_DIR:-$HOME/.ai-sync-cli}}"
 SYNC_DIR="$HOME/.ai-sync"
 BIN_LINK="/usr/local/bin/ai-sync"
@@ -231,19 +230,16 @@ ok "Node.js $(node -v | tr -d v) found"
 # ── install ────────────────────────────────────────────────────────
 
 if [ -d "$INSTALL_DIR/.git" ]; then
-  info "Updating existing installation in $INSTALL_DIR to $PINNED_VERSION..."
-  git -C "$INSTALL_DIR" fetch --depth 1 origin "refs/tags/$PINNED_VERSION"
-  git -C "$INSTALL_DIR" reset --hard FETCH_HEAD
+  info "Updating existing installation in $INSTALL_DIR..."
+  git -C "$INSTALL_DIR" fetch --depth 1 origin main
+  git -C "$INSTALL_DIR" reset --hard origin/main
 else
-  info "Cloning ai-sync $PINNED_VERSION into $INSTALL_DIR..."
-  git clone --depth 1 --branch "$PINNED_VERSION" "https://github.com/$REPO.git" "$INSTALL_DIR"
+  info "Cloning ai-sync into $INSTALL_DIR..."
+  git clone --depth 1 "https://github.com/$REPO.git" "$INSTALL_DIR"
 fi
 
 info "Installing dependencies..."
 (cd "$INSTALL_DIR" && npm install --no-fund --no-audit --loglevel=error)
-
-info "Updating package.json version to $PINNED_VERSION..."
-sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"${PINNED_VERSION#v}\"/" "$INSTALL_DIR/package.json" 2>/dev/null || true
 
 info "Building..."
 (cd "$INSTALL_DIR" && npm run build --silent)

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,27 @@ ok()    { printf '\033[1;32m%s\033[0m\n' "$*"; }
 warn()  { printf '\033[1;33m%s\033[0m\n' "$*"; }
 err()   { printf '\033[1;31mError: %s\033[0m\n' "$*" >&2; exit 1; }
 
+# Offer to star the repo on GitHub
+ask_star() {
+  echo ""
+  printf '\033[1;33m\u2B50 Enjoying ai-sync? Star us on GitHub to help others discover it!\033[0m\n'
+  printf '   \033[4mhttps://github.com/%s\033[0m\n' "$REPO"
+  echo ""
+  local answer
+  answer=$(prompt "Open in browser? (y/n)" "y")
+  if [ "$answer" = "y" ] || [ "$answer" = "Y" ]; then
+    if command -v open >/dev/null 2>&1; then
+      open "https://github.com/$REPO"
+    elif command -v xdg-open >/dev/null 2>&1; then
+      xdg-open "https://github.com/$REPO"
+    elif command -v wslview >/dev/null 2>&1; then
+      wslview "https://github.com/$REPO"
+    else
+      echo "  Visit: https://github.com/$REPO"
+    fi
+  fi
+}
+
 # Read user input — works even when script is piped via curl | bash
 # Returns the value via stdout; caller captures with $()
 prompt() {
@@ -303,7 +324,7 @@ if [ -d "$SYNC_DIR/.git" ]; then
   echo "  ai-sync push    # push local changes"
   echo "  ai-sync pull    # pull remote changes"
   echo "  ai-sync status  # check sync state"
-  echo ""
+  ask_star
   exit 0
 fi
 
@@ -407,4 +428,5 @@ ok "All done! Your config is synced to $REMOTE_URL"
 echo ""
 echo "On other machines, run:"
 echo "  curl -fsSL https://raw.githubusercontent.com/$REPO/main/install.sh | bash"
+ask_star
 echo ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 			"devDependencies": {
 				"@biomejs/biome": "^2.0.0",
 				"@types/node": "^22.0.0",
-				"@vitest/coverage-v8": "^4.1.0",
+				"@vitest/coverage-v8": "^4.1.4",
 				"memfs": "^4.0.0",
 				"tsup": "^8.5.0",
 				"typescript": "~5.9.3",
@@ -253,21 +253,21 @@
 			}
 		},
 		"node_modules/@emnapi/core": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-			"integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+			"integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.0",
+				"@emnapi/wasi-threads": "1.2.1",
 				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-			"integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+			"integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -276,9 +276,9 @@
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-			"integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1213,26 +1213,28 @@
 			"license": "MIT"
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-			"integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+			"integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/core": "^1.7.1",
-				"@emnapi/runtime": "^1.7.1",
 				"@tybys/wasm-util": "^0.10.1"
 			},
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.120.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.120.0.tgz",
-			"integrity": "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==",
+			"version": "0.124.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+			"integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -1240,9 +1242,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz",
-			"integrity": "sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==",
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+			"integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1257,9 +1259,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.10.tgz",
-			"integrity": "sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==",
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+			"integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1274,9 +1276,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.10.tgz",
-			"integrity": "sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==",
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+			"integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
 			"cpu": [
 				"x64"
 			],
@@ -1291,9 +1293,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.10.tgz",
-			"integrity": "sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==",
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+			"integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
 			"cpu": [
 				"x64"
 			],
@@ -1308,9 +1310,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.10.tgz",
-			"integrity": "sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==",
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+			"integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
 			"cpu": [
 				"arm"
 			],
@@ -1325,9 +1327,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.10.tgz",
-			"integrity": "sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==",
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+			"integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
 			"cpu": [
 				"arm64"
 			],
@@ -1342,9 +1344,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.10.tgz",
-			"integrity": "sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==",
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+			"integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1359,9 +1361,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.10.tgz",
-			"integrity": "sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==",
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+			"integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1376,9 +1378,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.10.tgz",
-			"integrity": "sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==",
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+			"integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -1393,9 +1395,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.10.tgz",
-			"integrity": "sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==",
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+			"integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
 			"cpu": [
 				"x64"
 			],
@@ -1410,9 +1412,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.10.tgz",
-			"integrity": "sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==",
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+			"integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
 			"cpu": [
 				"x64"
 			],
@@ -1427,9 +1429,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.10.tgz",
-			"integrity": "sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==",
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+			"integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1444,9 +1446,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.10.tgz",
-			"integrity": "sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==",
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+			"integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
 			"cpu": [
 				"wasm32"
 			],
@@ -1454,16 +1456,18 @@
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@napi-rs/wasm-runtime": "^1.1.1"
+				"@emnapi/core": "1.9.2",
+				"@emnapi/runtime": "1.9.2",
+				"@napi-rs/wasm-runtime": "^1.1.3"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.10.tgz",
-			"integrity": "sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==",
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+			"integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1478,9 +1482,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.10.tgz",
-			"integrity": "sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==",
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+			"integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
 			"cpu": [
 				"x64"
 			],
@@ -1495,9 +1499,9 @@
 			}
 		},
 		"node_modules/@rolldown/pluginutils": {
-			"version": "1.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.10.tgz",
-			"integrity": "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==",
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+			"integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1905,14 +1909,14 @@
 			}
 		},
 		"node_modules/@vitest/coverage-v8": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.0.tgz",
-			"integrity": "sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
+			"integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
-				"@vitest/utils": "4.1.0",
+				"@vitest/utils": "4.1.4",
 				"ast-v8-to-istanbul": "^1.0.0",
 				"istanbul-lib-coverage": "^3.2.2",
 				"istanbul-lib-report": "^3.0.1",
@@ -1920,14 +1924,14 @@
 				"magicast": "^0.5.2",
 				"obug": "^2.1.1",
 				"std-env": "^4.0.0-rc.1",
-				"tinyrainbow": "^3.0.3"
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/browser": "4.1.0",
-				"vitest": "4.1.0"
+				"@vitest/browser": "4.1.4",
+				"vitest": "4.1.4"
 			},
 			"peerDependenciesMeta": {
 				"@vitest/browser": {
@@ -1936,31 +1940,31 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
-			"integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+			"integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.0",
-				"@vitest/utils": "4.1.0",
+				"@vitest/spy": "4.1.4",
+				"@vitest/utils": "4.1.4",
 				"chai": "^6.2.2",
-				"tinyrainbow": "^3.0.3"
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
-			"integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+			"integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.0",
+				"@vitest/spy": "4.1.4",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -1969,7 +1973,7 @@
 			},
 			"peerDependencies": {
 				"msw": "^2.4.9",
-				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"msw": {
@@ -1981,26 +1985,26 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
-			"integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+			"integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tinyrainbow": "^3.0.3"
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
-			"integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+			"integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.0",
+				"@vitest/utils": "4.1.4",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -2008,14 +2012,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
-			"integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+			"integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.0",
-				"@vitest/utils": "4.1.0",
+				"@vitest/pretty-format": "4.1.4",
+				"@vitest/utils": "4.1.4",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -2024,9 +2028,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
-			"integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+			"integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -2034,15 +2038,15 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
-			"integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+			"integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.0",
+				"@vitest/pretty-format": "4.1.4",
 				"convert-source-map": "^2.0.0",
-				"tinyrainbow": "^3.0.3"
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
@@ -2860,9 +2864,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2991,14 +2995,14 @@
 			}
 		},
 		"node_modules/rolldown": {
-			"version": "1.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.10.tgz",
-			"integrity": "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==",
+			"version": "1.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+			"integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.120.0",
-				"@rolldown/pluginutils": "1.0.0-rc.10"
+				"@oxc-project/types": "=0.124.0",
+				"@rolldown/pluginutils": "1.0.0-rc.15"
 			},
 			"bin": {
 				"rolldown": "bin/cli.mjs"
@@ -3007,21 +3011,21 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.0-rc.10",
-				"@rolldown/binding-darwin-arm64": "1.0.0-rc.10",
-				"@rolldown/binding-darwin-x64": "1.0.0-rc.10",
-				"@rolldown/binding-freebsd-x64": "1.0.0-rc.10",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.10",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.10",
-				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.10",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.10",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.10",
-				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.10",
-				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.10",
-				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.10",
-				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.10",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.10",
-				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.10"
+				"@rolldown/binding-android-arm64": "1.0.0-rc.15",
+				"@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+				"@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+				"@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
 			}
 		},
 		"node_modules/rollup": {
@@ -3256,9 +3260,9 @@
 			}
 		},
 		"node_modules/tinyrainbow": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-			"integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3388,16 +3392,16 @@
 			"license": "MIT"
 		},
 		"node_modules/vite": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.1.tgz",
-			"integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
+			"version": "8.0.8",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+			"integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.32.0",
-				"picomatch": "^4.0.3",
+				"picomatch": "^4.0.4",
 				"postcss": "^8.5.8",
-				"rolldown": "1.0.0-rc.10",
+				"rolldown": "1.0.0-rc.15",
 				"tinyglobby": "^0.2.15"
 			},
 			"bin": {
@@ -3415,7 +3419,7 @@
 			"peerDependencies": {
 				"@types/node": "^20.19.0 || >=22.12.0",
 				"@vitejs/devtools": "^0.1.0",
-				"esbuild": "^0.27.0",
+				"esbuild": "^0.27.0 || ^0.28.0",
 				"jiti": ">=1.21.0",
 				"less": "^4.0.0",
 				"sass": "^1.70.0",
@@ -3466,19 +3470,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
-			"integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+			"integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.0",
-				"@vitest/mocker": "4.1.0",
-				"@vitest/pretty-format": "4.1.0",
-				"@vitest/runner": "4.1.0",
-				"@vitest/snapshot": "4.1.0",
-				"@vitest/spy": "4.1.0",
-				"@vitest/utils": "4.1.0",
+				"@vitest/expect": "4.1.4",
+				"@vitest/mocker": "4.1.4",
+				"@vitest/pretty-format": "4.1.4",
+				"@vitest/runner": "4.1.4",
+				"@vitest/snapshot": "4.1.4",
+				"@vitest/spy": "4.1.4",
+				"@vitest/utils": "4.1.4",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -3489,8 +3493,8 @@
 				"tinybench": "^2.9.0",
 				"tinyexec": "^1.0.2",
 				"tinyglobby": "^0.2.15",
-				"tinyrainbow": "^3.0.3",
-				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
 				"why-is-node-running": "^2.3.0"
 			},
 			"bin": {
@@ -3506,13 +3510,15 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.0",
-				"@vitest/browser-preview": "4.1.0",
-				"@vitest/browser-webdriverio": "4.1.0",
-				"@vitest/ui": "4.1.0",
+				"@vitest/browser-playwright": "4.1.4",
+				"@vitest/browser-preview": "4.1.4",
+				"@vitest/browser-webdriverio": "4.1.4",
+				"@vitest/coverage-istanbul": "4.1.4",
+				"@vitest/coverage-v8": "4.1.4",
+				"@vitest/ui": "4.1.4",
 				"happy-dom": "*",
 				"jsdom": "*",
-				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@edge-runtime/vm": {
@@ -3531,6 +3537,12 @@
 					"optional": true
 				},
 				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
 					"optional": true
 				},
 				"@vitest/ui": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.0.0",
 		"@types/node": "^22.0.0",
-		"@vitest/coverage-v8": "^4.1.0",
+		"@vitest/coverage-v8": "^4.1.4",
 		"memfs": "^4.0.0",
 		"tsup": "^8.5.0",
 		"typescript": "~5.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ai-sync",
-	"version": "0.2.1",
+	"version": "0.2.0",
 	"type": "module",
 	"bin": {
 		"ai-sync": "./dist/cli.js"
@@ -25,7 +25,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.0.0",
 		"@types/node": "^22.0.0",
-		"@vitest/coverage-v8": "^4.1.0",
+		"@vitest/coverage-v8": "^4.1.4",
 		"memfs": "^4.0.0",
 		"tsup": "^8.5.0",
 		"typescript": "~5.9.3",

--- a/src/cli/commands/bootstrap.ts
+++ b/src/cli/commands/bootstrap.ts
@@ -9,8 +9,11 @@ import { getEnabledEnvironmentInstances } from "../../core/env-config.js";
 import { makeAllowlistFn, needsPathRewrite } from "../../core/env-helpers.js";
 import { detectRepoVersion } from "../../core/migration.js";
 import { expandPathsForLocal } from "../../core/path-rewriter.js";
+import type { ProvisionResult } from "../../core/provisioner.js";
+import { preflightCheck, provision } from "../../core/provisioner.js";
 import { scanDirectory } from "../../core/scanner.js";
 import { installSkills } from "../../core/skills.js";
+import { ToolManifestSchema } from "../../core/tool-manifest.js";
 import { isGitRepo } from "../../git/repo.js";
 import { getClaudeDir, getSyncRepoDir } from "../../platform/paths.js";
 
@@ -31,8 +34,7 @@ function checkSshConnectivity(repoUrl: string): string | null {
 	}
 
 	try {
-		const sshHost = host === "github.com" ? "git@github.com" : host;
-		execSync(`ssh -T -o ConnectTimeout=5 -o StrictHostKeyChecking=yes ${sshHost}`, {
+		execSync(`ssh -T -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new ${host}`, {
 			stdio: "pipe",
 			timeout: 10_000,
 		});
@@ -45,13 +47,12 @@ function checkSshConnectivity(repoUrl: string): string | null {
 				return null;
 			}
 		}
-		const sshHost = host === "github.com" ? "git@github.com" : host;
 		return (
 			`SSH connection to ${host} failed. Check that:\n` +
 			"  1. Your SSH key is added to the agent: ssh-add -l\n" +
 			"  2. Your key is registered on GitHub: gh ssh-key list\n" +
 			"  3. You can reach the host: ssh -T " +
-			sshHost
+			host
 		);
 	}
 }
@@ -62,6 +63,7 @@ export interface BootstrapOptions {
 	claudeDir?: string;
 	force?: boolean;
 	verbose?: boolean;
+	noProvision?: boolean;
 }
 
 export interface BootstrapResult {
@@ -70,6 +72,7 @@ export interface BootstrapResult {
 	filesApplied: number;
 	backupDir: string | null;
 	message: string;
+	provisioning?: ProvisionResult;
 }
 
 /**
@@ -215,6 +218,37 @@ export async function handleBootstrap(options: BootstrapOptions): Promise<Bootst
 		}
 	}
 
+	// Tool provisioning (non-fatal)
+	let provisioningResult: ProvisionResult | undefined;
+	if (!options.noProvision) {
+		const manifestPath = path.join(syncRepoDir, "tools", "manifest.json");
+		try {
+			const manifestContent = await fs.readFile(manifestPath, "utf-8");
+			const manifest = ToolManifestSchema.parse(JSON.parse(manifestContent));
+			if (manifest.tools.length > 0) {
+				const preflight = await preflightCheck(manifest);
+				if (!preflight.ok) {
+					provisioningResult = {
+						installed: [],
+						skipped: [],
+						failed: [],
+						commands: [],
+						rolledBack: true,
+						rollbackPartial: false,
+					};
+				} else {
+					provisioningResult = await provision({
+						manifest,
+						autoInstall: manifest.autoInstall,
+						backupDir: backupDir || "",
+					});
+				}
+			}
+		} catch {
+			// No manifest or invalid — silently skip
+		}
+	}
+
 	return {
 		syncRepoDir,
 		claudeDir,
@@ -223,6 +257,7 @@ export async function handleBootstrap(options: BootstrapOptions): Promise<Bootst
 		message: backupDir
 			? `Bootstrapped ${totalApplied} files from ${options.repoUrl}. Backup at: ${backupDir}`
 			: `Bootstrapped ${totalApplied} files from ${options.repoUrl}`,
+		provisioning: provisioningResult,
 	};
 }
 
@@ -237,10 +272,17 @@ export function registerBootstrapCommand(program: Command): void {
 		.option("--repo-path <path>", "Custom sync repo path", getSyncRepoDir())
 		.option("--claude-dir <path>", "Custom ~/.claude path", getClaudeDir())
 		.option("-v, --verbose", "Show detailed progress", false)
+		.option("--no-provision", "Skip tool provisioning", false)
 		.action(
 			async (
 				repoUrl: string,
-				opts: { force: boolean; repoPath: string; claudeDir: string; verbose: boolean },
+				opts: {
+					force: boolean;
+					repoPath: string;
+					claudeDir: string;
+					verbose: boolean;
+					provision: boolean;
+				},
 			) => {
 				try {
 					const result = await handleBootstrap({
@@ -249,6 +291,7 @@ export function registerBootstrapCommand(program: Command): void {
 						repoPath: opts.repoPath,
 						claudeDir: opts.claudeDir,
 						verbose: opts.verbose,
+						noProvision: !opts.provision,
 					});
 					console.log(pc.green(`Bootstrapped ${result.filesApplied} files from remote`));
 					console.log(pc.green(`  Sync repo: ${result.syncRepoDir}`));

--- a/src/cli/commands/bootstrap.ts
+++ b/src/cli/commands/bootstrap.ts
@@ -9,8 +9,11 @@ import { getEnabledEnvironmentInstances } from "../../core/env-config.js";
 import { makeAllowlistFn, needsPathRewrite } from "../../core/env-helpers.js";
 import { detectRepoVersion } from "../../core/migration.js";
 import { expandPathsForLocal } from "../../core/path-rewriter.js";
+import type { ProvisionResult } from "../../core/provisioner.js";
+import { preflightCheck, provision } from "../../core/provisioner.js";
 import { scanDirectory } from "../../core/scanner.js";
 import { installSkills } from "../../core/skills.js";
+import { ToolManifestSchema } from "../../core/tool-manifest.js";
 import { isGitRepo } from "../../git/repo.js";
 import { getClaudeDir, getSyncRepoDir } from "../../platform/paths.js";
 
@@ -60,6 +63,7 @@ export interface BootstrapOptions {
 	claudeDir?: string;
 	force?: boolean;
 	verbose?: boolean;
+	noProvision?: boolean;
 }
 
 export interface BootstrapResult {
@@ -68,6 +72,7 @@ export interface BootstrapResult {
 	filesApplied: number;
 	backupDir: string | null;
 	message: string;
+	provisioning?: ProvisionResult;
 }
 
 /**
@@ -213,6 +218,37 @@ export async function handleBootstrap(options: BootstrapOptions): Promise<Bootst
 		}
 	}
 
+	// Tool provisioning (non-fatal)
+	let provisioningResult: ProvisionResult | undefined;
+	if (!options.noProvision) {
+		const manifestPath = path.join(syncRepoDir, "tools", "manifest.json");
+		try {
+			const manifestContent = await fs.readFile(manifestPath, "utf-8");
+			const manifest = ToolManifestSchema.parse(JSON.parse(manifestContent));
+			if (manifest.tools.length > 0) {
+				const preflight = await preflightCheck(manifest);
+				if (!preflight.ok) {
+					provisioningResult = {
+						installed: [],
+						skipped: [],
+						failed: [],
+						commands: [],
+						rolledBack: true,
+						rollbackPartial: false,
+					};
+				} else {
+					provisioningResult = await provision({
+						manifest,
+						autoInstall: manifest.autoInstall,
+						backupDir: backupDir || "",
+					});
+				}
+			}
+		} catch {
+			// No manifest or invalid — silently skip
+		}
+	}
+
 	return {
 		syncRepoDir,
 		claudeDir,
@@ -221,6 +257,7 @@ export async function handleBootstrap(options: BootstrapOptions): Promise<Bootst
 		message: backupDir
 			? `Bootstrapped ${totalApplied} files from ${options.repoUrl}. Backup at: ${backupDir}`
 			: `Bootstrapped ${totalApplied} files from ${options.repoUrl}`,
+		provisioning: provisioningResult,
 	};
 }
 
@@ -235,10 +272,17 @@ export function registerBootstrapCommand(program: Command): void {
 		.option("--repo-path <path>", "Custom sync repo path", getSyncRepoDir())
 		.option("--claude-dir <path>", "Custom ~/.claude path", getClaudeDir())
 		.option("-v, --verbose", "Show detailed progress", false)
+		.option("--no-provision", "Skip tool provisioning", false)
 		.action(
 			async (
 				repoUrl: string,
-				opts: { force: boolean; repoPath: string; claudeDir: string; verbose: boolean },
+				opts: {
+					force: boolean;
+					repoPath: string;
+					claudeDir: string;
+					verbose: boolean;
+					provision: boolean;
+				},
 			) => {
 				try {
 					const result = await handleBootstrap({
@@ -247,6 +291,7 @@ export function registerBootstrapCommand(program: Command): void {
 						repoPath: opts.repoPath,
 						claudeDir: opts.claudeDir,
 						verbose: opts.verbose,
+						noProvision: !opts.provision,
 					});
 					console.log(pc.green(`Bootstrapped ${result.filesApplied} files from remote`));
 					console.log(pc.green(`  Sync repo: ${result.syncRepoDir}`));

--- a/src/cli/commands/fragment.ts
+++ b/src/cli/commands/fragment.ts
@@ -1,0 +1,343 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { createBackup } from "../../core/backup.js";
+import {
+	generateIndex,
+	hasConflictMarkers,
+	parseIndex,
+	splitMarkdownIntoFragments,
+} from "../../core/fragmenter.js";
+import { detectRepoVersion, migrateToV3 } from "../../core/migration.js";
+import { getClaudeDir, getSyncRepoDir } from "../../platform/paths.js";
+
+export interface FragmentSplitOptions {
+	repoPath?: string;
+	claudeDir?: string;
+}
+
+export interface FragmentStatusOptions {
+	repoPath?: string;
+}
+
+export interface FragmentAddRemoveOptions {
+	repoPath?: string;
+}
+
+/**
+ * Slugifies a heading for use as a filename.
+ * e.g. "## My Section" → "my-section"
+ */
+function slugify(heading: string): string {
+	return heading
+		.replace(/^#+\s*/, "")
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-|-$/g, "");
+}
+
+/**
+ * The known section → fragment-path mapping used for splitting CLAUDE.md.
+ */
+const KNOWN_SECTION_MAP = new Map<string, string>([
+	["## TDD & Testing", "shared/standards/tdd.md"],
+	["## Stack", "shared/standards/stack.md"],
+	["## Architecture", "shared/standards/architecture.md"],
+	["## Code Quality", "shared/standards/code-quality.md"],
+	["## Database Safety", "shared/standards/database-safety.md"],
+	["## AWS", "shared/standards/aws.md"],
+	["## Dev Server", "shared/standards/dev-server.md"],
+	["## Workflow", "shared/standards/workflow.md"],
+	["## Worktrees", "shared/standards/worktrees.md"],
+	["## Context", "shared/context/context.md"],
+	["## Planning", "shared/context/planning.md"],
+]);
+
+/**
+ * Registers the "fragment" subcommand group on the CLI program.
+ */
+export function registerFragmentCommand(program: Command): void {
+	const fragment = program
+		.command("fragment")
+		.description("Manage fragment-based configuration files");
+
+	fragment
+		.command("split")
+		.description("Split CLAUDE.md into modular fragments")
+		.option("--repo-path <path>", "Custom sync repo path")
+		.option("--claude-dir <path>", "Custom Claude config directory")
+		.action(async (options: FragmentSplitOptions) => {
+			await handleFragmentSplit(options);
+		});
+
+	fragment
+		.command("status")
+		.description("Show fragment index and reference status")
+		.option("--repo-path <path>", "Custom sync repo path")
+		.action(async (options: FragmentStatusOptions) => {
+			await handleFragmentStatus(options);
+		});
+
+	fragment
+		.command("add <path>")
+		.description("Add an @-reference to the index")
+		.option("--repo-path <path>", "Custom sync repo path")
+		.action(async (refPath: string, options: FragmentAddRemoveOptions) => {
+			await handleFragmentAdd(refPath, options);
+		});
+
+	fragment
+		.command("remove <path>")
+		.description("Remove an @-reference from the index")
+		.option("--repo-path <path>", "Custom sync repo path")
+		.action(async (refPath: string, options: FragmentAddRemoveOptions) => {
+			await handleFragmentRemove(refPath, options);
+		});
+}
+
+/**
+ * Splits a monolithic CLAUDE.md into fragment files in the sync repo.
+ *
+ * 1. Reads claudeDir/CLAUDE.md
+ * 2. Skips if already a symlink (already migrated)
+ * 3. Splits using splitMarkdownIntoFragments with the known section map,
+ *    routing unrecognised ## sections to claude/orchestration/<slug>.md
+ * 4. Writes fragment files into syncRepoDir
+ * 5. Writes the index to syncRepoDir/claude/CLAUDE.md
+ * 6. Backs up the original CLAUDE.md
+ * 7. Creates a symlink: claudeDir/CLAUDE.md → syncRepoDir/claude/CLAUDE.md
+ * 8. Upgrades the repo to v3 if needed
+ */
+export async function handleFragmentSplit(options: FragmentSplitOptions): Promise<void> {
+	try {
+		const claudeDir = options.claudeDir ?? getClaudeDir();
+		const syncRepoDir = getSyncRepoDir(options.repoPath);
+		const claudeMdPath = path.join(claudeDir, "CLAUDE.md");
+
+		// Read source file
+		let content: string;
+		try {
+			content = await fs.readFile(claudeMdPath, "utf-8");
+		} catch {
+			console.error(pc.red(`Could not read ${claudeMdPath}`));
+			process.exitCode = 1;
+			return;
+		}
+
+		// Check whether it is already a symlink
+		try {
+			const stat = await fs.lstat(claudeMdPath);
+			if (stat.isSymbolicLink()) {
+				console.log(pc.yellow(`${claudeMdPath} is already a symlink — already migrated, skipping`));
+				return;
+			}
+		} catch {
+			// lstat failed — file doesn't exist
+			console.error(pc.red(`Could not stat ${claudeMdPath}`));
+			process.exitCode = 1;
+			return;
+		}
+
+		// Build the full section map, routing unknown ## sections to orchestration
+		const lines = content.split("\n");
+		const sectionMap = new Map<string, string>(KNOWN_SECTION_MAP);
+		for (const line of lines) {
+			if (line.startsWith("## ") && !sectionMap.has(line)) {
+				const slug = slugify(line);
+				sectionMap.set(line, `claude/orchestration/${slug}.md`);
+			}
+		}
+
+		// Split content into fragments
+		const result = splitMarkdownIntoFragments(content, sectionMap);
+
+		// Create required directories in sync repo
+		const dirs = [
+			path.join(syncRepoDir, "shared/standards"),
+			path.join(syncRepoDir, "shared/context"),
+			path.join(syncRepoDir, "claude/orchestration"),
+		];
+		for (const dir of dirs) {
+			await fs.mkdir(dir, { recursive: true });
+		}
+
+		// Write fragment files
+		for (const fragment of result.fragments) {
+			const fragmentAbsPath = path.join(syncRepoDir, fragment.path);
+			await fs.mkdir(path.dirname(fragmentAbsPath), { recursive: true });
+			await fs.writeFile(fragmentAbsPath, `${fragment.content}\n`);
+			console.log(pc.dim(`  wrote ${fragment.path}`));
+		}
+
+		// Write index file
+		const indexPath = path.join(syncRepoDir, "claude", "CLAUDE.md");
+		await fs.mkdir(path.dirname(indexPath), { recursive: true });
+		await fs.writeFile(indexPath, `${result.indexContent}\n`);
+		console.log(pc.dim(`  wrote claude/CLAUDE.md (index)`));
+
+		// Back up original
+		const backupBaseDir = path.join(path.dirname(syncRepoDir), ".ai-sync-backups");
+		await createBackup(claudeDir, backupBaseDir, (rel) => rel === "CLAUDE.md");
+		console.log(pc.dim(`  backed up original CLAUDE.md`));
+
+		// Replace original with symlink
+		await fs.rm(claudeMdPath);
+		await fs.symlink(indexPath, claudeMdPath);
+
+		// Upgrade to v3 if needed
+		const version = await detectRepoVersion(syncRepoDir);
+		if (version < 3) {
+			if (version === 1) {
+				console.log(
+					pc.yellow("Repo is at v1. Please run 'ai-sync migrate' to upgrade to v2 first."),
+				);
+			} else {
+				await migrateToV3(syncRepoDir);
+				console.log(pc.dim("  auto-upgraded sync repo to v3"));
+			}
+		}
+
+		console.log(pc.green(`\nSplit complete: ${result.fragments.length} fragments created`));
+		console.log(pc.dim(`  index: ${indexPath}`));
+		console.log(pc.dim(`  symlink: ${claudeMdPath} → ${indexPath}`));
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(pc.red(`Fragment split failed: ${message}`));
+		process.exitCode = 1;
+	}
+}
+
+/**
+ * Reads the fragment index from the sync repo and reports the status of each @-reference.
+ */
+export async function handleFragmentStatus(options: FragmentStatusOptions): Promise<void> {
+	try {
+		const syncRepoDir = getSyncRepoDir(options.repoPath);
+		const indexPath = path.join(syncRepoDir, "claude", "CLAUDE.md");
+
+		let indexContent: string;
+		try {
+			indexContent = await fs.readFile(indexPath, "utf-8");
+		} catch {
+			console.error(pc.red(`Could not read index at ${indexPath}`));
+			process.exitCode = 1;
+			return;
+		}
+
+		const index = parseIndex(indexContent);
+
+		if (index.references.length === 0) {
+			console.log(pc.yellow("No @-references found in the index"));
+			return;
+		}
+
+		console.log(pc.cyan(`Fragment index: ${indexPath}`));
+		console.log(pc.cyan(`References (${index.references.length}):`));
+
+		for (const ref of index.references) {
+			const absPath = path.join(syncRepoDir, ref);
+			let status: string;
+			let hasConflicts = false;
+
+			try {
+				const fileContent = await fs.readFile(absPath, "utf-8");
+				hasConflicts = hasConflictMarkers(fileContent);
+				status = hasConflicts ? pc.red("conflict") : pc.green("ok");
+			} catch {
+				status = pc.red("missing");
+			}
+
+			const conflictSuffix = hasConflicts ? pc.red(" [has conflict markers]") : "";
+			console.log(`  ${status}  @${ref}${conflictSuffix}`);
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(pc.red(`Fragment status failed: ${message}`));
+		process.exitCode = 1;
+	}
+}
+
+/**
+ * Adds an @-reference to the fragment index.
+ */
+export async function handleFragmentAdd(
+	refPath: string,
+	options: FragmentAddRemoveOptions,
+): Promise<void> {
+	try {
+		const syncRepoDir = getSyncRepoDir(options.repoPath);
+		const indexPath = path.join(syncRepoDir, "claude", "CLAUDE.md");
+
+		let indexContent: string;
+		try {
+			indexContent = await fs.readFile(indexPath, "utf-8");
+		} catch {
+			console.error(pc.red(`Could not read index at ${indexPath}`));
+			process.exitCode = 1;
+			return;
+		}
+
+		const index = parseIndex(indexContent);
+
+		// Normalise the ref (strip leading @)
+		const normalised = refPath.startsWith("@") ? refPath.slice(1) : refPath;
+
+		if (index.references.includes(normalised)) {
+			console.log(pc.yellow(`@${normalised} is already in the index`));
+			return;
+		}
+
+		index.references.push(normalised);
+		const newContent = generateIndex(index.preamble, index.references);
+		await fs.writeFile(indexPath, `${newContent}\n`);
+
+		console.log(pc.green(`Added @${normalised} to the index`));
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(pc.red(`Fragment add failed: ${message}`));
+		process.exitCode = 1;
+	}
+}
+
+/**
+ * Removes an @-reference from the fragment index.
+ */
+export async function handleFragmentRemove(
+	refPath: string,
+	options: FragmentAddRemoveOptions,
+): Promise<void> {
+	try {
+		const syncRepoDir = getSyncRepoDir(options.repoPath);
+		const indexPath = path.join(syncRepoDir, "claude", "CLAUDE.md");
+
+		let indexContent: string;
+		try {
+			indexContent = await fs.readFile(indexPath, "utf-8");
+		} catch {
+			console.error(pc.red(`Could not read index at ${indexPath}`));
+			process.exitCode = 1;
+			return;
+		}
+
+		const index = parseIndex(indexContent);
+
+		const normalised = refPath.startsWith("@") ? refPath.slice(1) : refPath;
+		const before = index.references.length;
+		index.references = index.references.filter((r) => r !== normalised);
+
+		if (index.references.length === before) {
+			console.log(pc.yellow(`@${normalised} was not found in the index`));
+			return;
+		}
+
+		const newContent = generateIndex(index.preamble, index.references);
+		await fs.writeFile(indexPath, `${newContent}\n`);
+
+		console.log(pc.green(`Removed @${normalised} from the index`));
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(pc.red(`Fragment remove failed: ${message}`));
+		process.exitCode = 1;
+	}
+}

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -7,7 +7,14 @@ import { makeAllowlistFn, needsPathRewrite } from "../../core/env-helpers.js";
 import { rewritePathsForRepo } from "../../core/path-rewriter.js";
 import { scanDirectory } from "../../core/scanner.js";
 import { installSkills } from "../../core/skills.js";
-import { addFiles, commitFiles, initRepo, isGitRepo, writeGitattributes } from "../../git/repo.js";
+import {
+	addFiles,
+	commitFiles,
+	getStatus,
+	initRepo,
+	isGitRepo,
+	writeGitattributes,
+} from "../../git/repo.js";
 import { getClaudeDir, getSyncRepoDir } from "../../platform/paths.js";
 
 /**
@@ -109,7 +116,11 @@ export async function handleInit(options: InitOptions): Promise<InitResult> {
 
 		// Commit synced files
 		if (totalCopied > 0) {
-			await addFiles(syncRepoDir, ["."]);
+			const initStatus = await getStatus(syncRepoDir);
+			const filesToStage = initStatus.files.map((f) => f.path);
+			if (filesToStage.length > 0) {
+				await addFiles(syncRepoDir, filesToStage);
+			}
 			await commitFiles(syncRepoDir, "feat: initial sync of config");
 		}
 

--- a/src/cli/commands/pull.ts
+++ b/src/cli/commands/pull.ts
@@ -16,6 +16,7 @@ export interface PullOptions {
 	env?: string;
 	verbose?: boolean;
 	force?: boolean;
+	noProvision?: boolean;
 }
 
 /**
@@ -32,6 +33,7 @@ export async function handlePull(options: PullOptions): Promise<SyncPullResult> 
 		filterEnv: options.env,
 		verbose: options.verbose,
 		force: options.force,
+		noProvision: options.noProvision,
 	});
 }
 
@@ -48,47 +50,58 @@ export function registerPullCommand(program: Command): void {
 		.option("-n, --dry-run", "Show what would be pulled without making changes", false)
 		.option("-f, --force", "Overwrite locally modified files instead of preserving them", false)
 		.option("--env <id>", "Only pull a specific environment (e.g., claude or opencode)")
-		.action(async (opts) => {
-			try {
-				const result = await handlePull(opts);
-				if (result.errors) {
-					for (const [envId, message] of Object.entries(result.errors)) {
-						console.error(pc.red(`  ${envId}: ${message}`));
+		.option("--no-provision", "Skip tool provisioning", false)
+		.action(
+			async (opts: {
+				repoPath?: string;
+				claudeDir?: string;
+				verbose: boolean;
+				dryRun: boolean;
+				force: boolean;
+				env?: string;
+				provision: boolean;
+			}) => {
+				try {
+					const result = await handlePull({ ...opts, noProvision: !opts.provision });
+					if (result.errors) {
+						for (const [envId, message] of Object.entries(result.errors)) {
+							console.error(pc.red(`  ${envId}: ${message}`));
+						}
 					}
-				}
-				if (opts.verbose && result.fileChanges.length > 0) {
-					printFileChanges(result.fileChanges);
-				}
-				if (result.dryRun) {
-					console.log(pc.cyan(result.message));
-				} else if (result.fileChanges.length > 0) {
-					console.log(pc.green(`Pulled ${result.fileChanges.length} changed files from remote`));
-				} else {
-					console.log(pc.green("Pulled from remote -- already up to date"));
-				}
-				if (result.conflicts && result.conflicts.length > 0) {
-					console.log(
-						pc.yellow(
-							`\n${result.conflicts.length} file(s) had local changes — kept local versions:`,
-						),
-					);
-					for (const c of result.conflicts) {
-						const label = c.type === "deleted" ? "(remote deleted)" : "(both modified)";
-						console.log(pc.yellow(`  ${c.path} ${label}`));
+					if (opts.verbose && result.fileChanges.length > 0) {
+						printFileChanges(result.fileChanges);
 					}
-					console.log(
-						pc.yellow(
-							"\nRun 'ai-sync push' to publish your local changes, or 'ai-sync pull --force' to overwrite.",
-						),
-					);
+					if (result.dryRun) {
+						console.log(pc.cyan(result.message));
+					} else if (result.fileChanges.length > 0) {
+						console.log(pc.green(`Pulled ${result.fileChanges.length} changed files from remote`));
+					} else {
+						console.log(pc.green("Pulled from remote -- already up to date"));
+					}
+					if (result.conflicts && result.conflicts.length > 0) {
+						console.log(
+							pc.yellow(
+								`\n${result.conflicts.length} file(s) had local changes — kept local versions:`,
+							),
+						);
+						for (const c of result.conflicts) {
+							const label = c.type === "deleted" ? "(remote deleted)" : "(both modified)";
+							console.log(pc.yellow(`  ${c.path} ${label}`));
+						}
+						console.log(
+							pc.yellow(
+								"\nRun 'ai-sync push' to publish your local changes, or 'ai-sync pull --force' to overwrite.",
+							),
+						);
+					}
+					if (!result.dryRun && result.backupDir) {
+						console.log(pc.dim(`Backup saved to: ${result.backupDir}`));
+					}
+				} catch (error) {
+					const message = error instanceof Error ? error.message : String(error);
+					console.error(pc.red(`Pull failed: ${message}`));
+					process.exitCode = 1;
 				}
-				if (!result.dryRun && result.backupDir) {
-					console.log(pc.dim(`Backup saved to: ${result.backupDir}`));
-				}
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				console.error(pc.red(`Pull failed: ${message}`));
-				process.exitCode = 1;
-			}
-		});
+			},
+		);
 }

--- a/src/cli/commands/pull.ts
+++ b/src/cli/commands/pull.ts
@@ -50,7 +50,7 @@ export function registerPullCommand(program: Command): void {
 		.option("-n, --dry-run", "Show what would be pulled without making changes", false)
 		.option("-f, --force", "Overwrite locally modified files instead of preserving them", false)
 		.option("--env <id>", "Only pull a specific environment (e.g., claude or opencode)")
-		.option("--no-provision", "Skip tool provisioning", false)
+		.option("--no-provision", "Skip tool provisioning")
 		.action(
 			async (opts: {
 				repoPath?: string;
@@ -93,6 +93,34 @@ export function registerPullCommand(program: Command): void {
 								"\nRun 'ai-sync push' to publish your local changes, or 'ai-sync pull --force' to overwrite.",
 							),
 						);
+					}
+					if (result.provisioning) {
+						const p = result.provisioning;
+						if (p.commands.length > 0) {
+							console.log(pc.cyan("\nTool provisioning (autoInstall: off):"));
+							for (const cmd of p.commands) {
+								console.log(pc.cyan(`  ${cmd}`));
+							}
+						}
+						if (p.installed.length > 0) {
+							console.log(
+								pc.green(`\nProvisioned ${p.installed.length} tool(s)`),
+							);
+						}
+						if (p.failed.length > 0) {
+							console.log(
+								pc.red(
+									`\n${p.failed.length} tool(s) failed to install`,
+								),
+							);
+						}
+						if (p.skipped.length > 0 && opts.verbose) {
+							console.log(
+								pc.dim(
+									`${p.skipped.length} tool(s) already installed`,
+								),
+							);
+						}
 					}
 					if (!result.dryRun && result.backupDir) {
 						console.log(pc.dim(`Backup saved to: ${result.backupDir}`));

--- a/src/cli/commands/push.ts
+++ b/src/cli/commands/push.ts
@@ -15,6 +15,7 @@ export interface PushOptions {
 	dryRun?: boolean;
 	env?: string;
 	verbose?: boolean;
+	skipDiscovery?: boolean;
 }
 
 /**
@@ -30,6 +31,7 @@ export async function handlePush(options: PushOptions): Promise<SyncPushResult> 
 		dryRun: options.dryRun,
 		filterEnv: options.env,
 		verbose: options.verbose,
+		skipDiscovery: options.skipDiscovery,
 	});
 }
 
@@ -54,30 +56,40 @@ export function registerPushCommand(program: Command): void {
 		.option("-v, --verbose", "Show detailed file changes", false)
 		.option("-n, --dry-run", "Show what would be pushed without making changes", false)
 		.option("--env <id>", "Only push a specific environment (e.g., claude or opencode)")
-		.action(async (opts) => {
-			try {
-				const result = await handlePush(opts);
-				if (result.errors) {
-					console.error(pc.red("Errors during push:"));
-					printErrors(result.errors);
-				}
-				if (result.dryRun) {
-					if (opts.verbose && result.fileChanges.length > 0) {
-						printFileChanges(result.fileChanges);
+		.option("--skip-discovery", "Skip tool discovery", false)
+		.action(
+			async (opts: {
+				repoPath?: string;
+				claudeDir?: string;
+				verbose: boolean;
+				dryRun: boolean;
+				env?: string;
+				skipDiscovery: boolean;
+			}) => {
+				try {
+					const result = await handlePush(opts);
+					if (result.errors) {
+						console.error(pc.red("Errors during push:"));
+						printErrors(result.errors);
 					}
-					console.log(pc.cyan(result.message));
-				} else if (result.pushed) {
-					if (opts.verbose && result.fileChanges.length > 0) {
-						printFileChanges(result.fileChanges);
+					if (result.dryRun) {
+						if (opts.verbose && result.fileChanges.length > 0) {
+							printFileChanges(result.fileChanges);
+						}
+						console.log(pc.cyan(result.message));
+					} else if (result.pushed) {
+						if (opts.verbose && result.fileChanges.length > 0) {
+							printFileChanges(result.fileChanges);
+						}
+						console.log(pc.green(result.message));
+					} else {
+						console.log(pc.yellow("No changes to push -- already up to date"));
 					}
-					console.log(pc.green(result.message));
-				} else {
-					console.log(pc.yellow("No changes to push -- already up to date"));
+				} catch (error) {
+					const message = error instanceof Error ? error.message : String(error);
+					console.error(pc.red(`Push failed: ${message}`));
+					process.exitCode = 1;
 				}
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				console.error(pc.red(`Push failed: ${message}`));
-				process.exitCode = 1;
-			}
-		});
+			},
+		);
 }

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -1,8 +1,12 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import type { Command } from "commander";
 import pc from "picocolors";
 import { getEnabledEnvironmentInstances } from "../../core/env-config.js";
+import { verifyTool } from "../../core/provisioner.js";
 import type { SyncStatusResult } from "../../core/sync-engine.js";
 import { syncStatus } from "../../core/sync-engine.js";
+import { ToolManifestSchema } from "../../core/tool-manifest.js";
 import { getClaudeDir, getSyncRepoDir } from "../../platform/paths.js";
 import { printFileChanges } from "../format.js";
 
@@ -87,6 +91,24 @@ export function registerStatusCommand(program: Command): void {
 					console.log(pc.dim(`Synced: ${result.syncedCount} files`));
 				}
 				console.log(pc.dim(`Excluded: ${result.excludedCount} files (not in sync manifest)`));
+
+				// Tool status from manifest
+				const syncRepoDir = opts.repoPath ?? getSyncRepoDir();
+				const manifestPath = path.join(syncRepoDir, "tools", "manifest.json");
+				try {
+					const manifestContent = await fs.readFile(manifestPath, "utf-8");
+					const manifest = ToolManifestSchema.parse(JSON.parse(manifestContent));
+					if (manifest.tools.length > 0) {
+						console.log(pc.dim(`\nTools (${manifest.tools.length}):`));
+						for (const tool of manifest.tools) {
+							const installed = await verifyTool(tool);
+							const status = installed ? pc.green("installed") : pc.yellow("missing");
+							console.log(`  ${tool.name} (${tool.type}): ${status}`);
+						}
+					}
+				} catch {
+					// No manifest — silently skip
+				}
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				console.error(pc.red(`Status failed: ${message}`));

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,6 +6,7 @@ import pc from "picocolors";
 import { startupUpdateCheck } from "../core/updater.js";
 import { registerBootstrapCommand } from "./commands/bootstrap.js";
 import { registerEnvCommand } from "./commands/env.js";
+import { registerFragmentCommand } from "./commands/fragment.js";
 import { registerInitCommand } from "./commands/init.js";
 import { registerInstallSkillsCommand } from "./commands/install-skills.js";
 import { registerLinkCommand } from "./commands/link.js";
@@ -70,6 +71,7 @@ registerInstallSkillsCommand(program);
 registerEnvCommand(program);
 registerLinkCommand(program);
 registerMigrateCommand(program);
+registerFragmentCommand(program);
 
 export { program };
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,6 +6,7 @@ import pc from "picocolors";
 import { startupUpdateCheck } from "../core/updater.js";
 import { registerBootstrapCommand } from "./commands/bootstrap.js";
 import { registerEnvCommand } from "./commands/env.js";
+import { registerFragmentCommand } from "./commands/fragment.js";
 import { registerInitCommand } from "./commands/init.js";
 import { registerInstallSkillsCommand } from "./commands/install-skills.js";
 import { registerLinkCommand } from "./commands/link.js";
@@ -54,8 +55,8 @@ program
 			"  ai-sync link                  Symlink config to sync repo (single source of truth)\n" +
 			"  ai-sync unlink                Revert symlinks back to regular files\n" +
 			"  ai-sync migrate               Migrate v1 repo to v2 multi-env format\n\n" +
-			"Update check: ai-sync notifies you of available updates once every 24 hours.\n" +
-			"Run 'ai-sync update' to apply. Disable notifications with --no-update-check.",
+			"Auto-update: ai-sync checks for updates once every 24 hours.\n" +
+			"Disable with --no-update-check.",
 	)
 	.version(getVersion())
 	.option("--no-update-check", "Skip automatic update check on startup");
@@ -70,6 +71,7 @@ registerInstallSkillsCommand(program);
 registerEnvCommand(program);
 registerLinkCommand(program);
 registerMigrateCommand(program);
+registerFragmentCommand(program);
 
 export { program };
 

--- a/src/core/env-helpers.ts
+++ b/src/core/env-helpers.ts
@@ -1,15 +1,16 @@
 import * as path from "node:path";
-import type { Environment } from "./environment.js";
+import { type Environment, isFragmentCapable } from "./environment.js";
 import { isPathAllowed } from "./manifest.js";
 
 /**
  * Creates an allowlist function for an environment's sync targets.
  */
 export function makeAllowlistFn(env: Environment): (relativePath: string) => boolean {
+	const fragmentDirs = isFragmentCapable(env) ? env.getFragmentDirs() : [];
 	return (relativePath: string) =>
 		isPathAllowed(
 			relativePath,
-			env.getSyncTargets(),
+			[...env.getSyncTargets(), ...fragmentDirs],
 			env.getPluginSyncPatterns(),
 			env.getIgnorePatterns(),
 		);

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -26,9 +26,22 @@ export interface Environment {
 }
 
 /**
+ * Optional capability for environments that support fragment-based config files.
+ * Use isFragmentCapable() type guard to check at runtime.
+ */
+export interface FragmentCapable {
+	getFragmentDirs(): string[];
+	getIndexFile(): string;
+}
+
+export function isFragmentCapable(env: Environment): env is Environment & FragmentCapable {
+	return "getFragmentDirs" in env && "getIndexFile" in env;
+}
+
+/**
  * Claude Code environment — config lives at ~/.claude
  */
-export class ClaudeEnvironment implements Environment {
+export class ClaudeEnvironment implements Environment, FragmentCapable {
 	readonly id = "claude";
 	readonly displayName = "Claude Code";
 
@@ -73,6 +86,14 @@ export class ClaudeEnvironment implements Environment {
 
 	getSkillsSubdir(): string | null {
 		return "commands";
+	}
+
+	getFragmentDirs(): string[] {
+		return ["shared/", "claude/orchestration/"];
+	}
+
+	getIndexFile(): string {
+		return "CLAUDE.md";
 	}
 }
 

--- a/src/core/fragmenter.ts
+++ b/src/core/fragmenter.ts
@@ -1,0 +1,190 @@
+import * as path from "node:path";
+
+/**
+ * A fragment is a single section extracted from a monolithic markdown file.
+ */
+export interface Fragment {
+	path: string; // Relative path in sync repo (e.g., "shared/standards/tdd.md")
+	content: string;
+	scope: "shared" | string; // "shared" or environment id
+}
+
+/**
+ * Parsed representation of a thin index file containing @-references.
+ */
+export interface FragmentIndex {
+	preamble: string; // Content before @-references
+	references: string[]; // Ordered @-reference paths
+}
+
+/**
+ * Result of splitting a monolithic markdown file into fragments.
+ */
+export interface SplitResult {
+	fragments: Fragment[];
+	indexContent: string;
+	sourcePath: string;
+}
+
+/**
+ * Splits a monolithic markdown file into fragment files by level-2 headers.
+ *
+ * Only `## ` headers are used as split points. Nested `###`, `####`, etc.
+ * remain within their parent fragment. Content before the first `## ` header
+ * becomes the preamble and is included in the generated index file but not
+ * emitted as a separate fragment.
+ *
+ * Empty sections (blank content after stripping whitespace) are skipped.
+ *
+ * @param content - The full markdown content to split
+ * @param sectionMap - Maps header text (e.g. `"## TDD & Testing"`) to fragment path
+ * @returns SplitResult with fragments and generated index content
+ */
+export function splitMarkdownIntoFragments(
+	content: string,
+	sectionMap: Map<string, string>,
+): SplitResult {
+	const lines = content.split("\n");
+
+	const preambleLines: string[] = [];
+	let currentHeader: string | null = null;
+	let currentLines: string[] = [];
+	const fragments: Fragment[] = [];
+	const references: string[] = [];
+
+	const flushSection = (): void => {
+		if (currentHeader === null) return;
+
+		const fragmentPath = sectionMap.get(currentHeader);
+		if (!fragmentPath) return;
+
+		// Join and trim trailing whitespace only; preserve internal structure
+		const sectionContent = currentLines.join("\n").trimEnd();
+		if (sectionContent.length === 0) return;
+
+		// Infer scope from path: first segment before "/"
+		const firstSegment = fragmentPath.split("/")[0] ?? "shared";
+		const scope: "shared" | string = firstSegment;
+
+		fragments.push({ path: fragmentPath, content: sectionContent, scope });
+		references.push(fragmentPath);
+	};
+
+	let inPreamble = true;
+
+	for (const line of lines) {
+		if (line.startsWith("## ")) {
+			if (inPreamble) {
+				// First ## header — everything so far is preamble
+				inPreamble = false;
+			} else {
+				// Flush previous section
+				flushSection();
+			}
+			currentHeader = line;
+			currentLines = [line];
+		} else if (inPreamble) {
+			preambleLines.push(line);
+		} else {
+			currentLines.push(line);
+		}
+	}
+
+	// Flush the last section
+	flushSection();
+
+	// Build preamble string, trimming trailing blank lines
+	const preamble = preambleLines.join("\n").trimEnd();
+
+	const indexContent = generateIndex(preamble, references);
+
+	return { fragments, indexContent, sourcePath: "" };
+}
+
+/**
+ * Generates a thin index file from a preamble and an ordered list of @-references.
+ *
+ * Output format:
+ * ```
+ * <preamble content>
+ *
+ * @shared/standards/tdd.md
+ * @shared/standards/code-quality.md
+ * ```
+ *
+ * @param preamble - Content to place before the references
+ * @param references - Ordered fragment paths (without leading `@`)
+ * @returns The full index file content
+ */
+export function generateIndex(preamble: string, references: string[]): string {
+	if (references.length === 0) {
+		return preamble;
+	}
+
+	const refLines = references.map((ref) => `@${ref}`).join("\n");
+
+	if (preamble.length === 0) {
+		return refLines;
+	}
+
+	return `${preamble}\n\n${refLines}`;
+}
+
+/**
+ * Parses a thin index file into its preamble and @-reference paths.
+ *
+ * Lines starting with `@` (after trimming) are treated as references.
+ * All non-reference lines that appear before the first reference are collected
+ * as the preamble.
+ *
+ * @param content - The index file content to parse
+ * @returns FragmentIndex with preamble and reference paths
+ */
+export function parseIndex(content: string): FragmentIndex {
+	const lines = content.split("\n");
+	const preambleLines: string[] = [];
+	const references: string[] = [];
+	let seenReference = false;
+
+	for (const line of lines) {
+		if (line.trim().startsWith("@")) {
+			seenReference = true;
+			references.push(line.trim().slice(1));
+		} else if (!seenReference) {
+			preambleLines.push(line);
+		}
+	}
+
+	// Trim trailing blank lines from preamble
+	const preamble = preambleLines.join("\n").trimEnd();
+
+	return { preamble, references };
+}
+
+/**
+ * Resolves an @-reference to an absolute path within the sync repository.
+ *
+ * Strips the leading `@` from the reference string, then joins the result
+ * with the sync repository root directory.
+ *
+ * @param reference - The @-reference string (e.g., `@shared/standards/tdd.md`)
+ * @param syncRepoDir - Absolute path to the sync repository root
+ * @returns Absolute path to the fragment file
+ */
+export function resolveFragmentPath(reference: string, syncRepoDir: string): string {
+	const stripped = reference.startsWith("@") ? reference.slice(1) : reference;
+	return path.join(syncRepoDir, stripped);
+}
+
+/**
+ * Returns true if the content contains git conflict markers.
+ *
+ * Checks for the presence of `<<<<<<<` or `>>>>>>>` which indicate
+ * an unresolved merge conflict.
+ *
+ * @param content - The file content to inspect
+ * @returns true if conflict markers are present
+ */
+export function hasConflictMarkers(content: string): boolean {
+	return content.includes("<<<<<<<") || content.includes(">>>>>>>");
+}

--- a/src/core/linker.ts
+++ b/src/core/linker.ts
@@ -206,6 +206,56 @@ export async function unlinkEnvironment(
 }
 
 /**
+ * Symlinks the shared fragment directory from the sync repo into a config dir.
+ * This allows @-references in CLAUDE.md to resolve relative to the config dir.
+ */
+export async function linkSharedDirectory(
+	syncRepoDir: string,
+	configDir: string,
+	backupDir: string,
+): Promise<{ linked: boolean; backedUp: boolean }> {
+	const repoSharedDir = path.join(syncRepoDir, "shared");
+
+	// 1. Check if syncRepoDir/shared/ exists
+	try {
+		await fs.access(repoSharedDir);
+	} catch {
+		return { linked: false, backedUp: false };
+	}
+
+	const configSharedPath = path.join(configDir, "shared");
+	let backedUp = false;
+
+	// 2. Check if configDir/shared already exists
+	let existingStat: import("node:fs").Stats | null = null;
+	try {
+		existingStat = await fs.lstat(configSharedPath);
+	} catch {
+		// Does not exist — nothing to do before linking
+	}
+
+	if (existingStat !== null) {
+		if (existingStat.isSymbolicLink()) {
+			// Remove the old symlink
+			await fs.rm(configSharedPath);
+		} else {
+			// Real directory: back it up, then remove
+			const backupPath = path.join(backupDir, "shared");
+			await fs.mkdir(path.dirname(backupPath), { recursive: true });
+			await copyRecursive(configSharedPath, backupPath);
+			backedUp = true;
+			await fs.rm(configSharedPath, { recursive: true });
+		}
+	}
+
+	// 3. Create symlink: configDir/shared -> syncRepoDir/shared
+	await fs.mkdir(configDir, { recursive: true });
+	await fs.symlink(repoSharedDir, configSharedPath);
+
+	return { linked: true, backedUp };
+}
+
+/**
  * Recursively copies a file or directory.
  */
 async function copyRecursive(src: string, dest: string): Promise<void> {

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -39,6 +39,27 @@ export const PLUGIN_IGNORE_PATTERNS: readonly string[] = [
 ] as const;
 
 /**
+ * Repo-level sync targets that live outside any environment subdirectory.
+ * These paths are relative to the sync repo root, not to any env subdirectory.
+ */
+export const REPO_LEVEL_SYNC_TARGETS: readonly string[] = [
+	"shared/", // All shared fragments
+	"tools/", // Tool manifest directory
+] as const;
+
+/**
+ * Checks whether a repo-root-relative path is in the repo-level sync targets.
+ * Used for paths like "shared/standards/tdd.md" and "tools/manifest.json".
+ */
+export function isRepoLevelPathAllowed(relativePath: string): boolean {
+	for (const target of REPO_LEVEL_SYNC_TARGETS) {
+		if (target.endsWith("/") && relativePath.startsWith(target)) return true;
+		if (relativePath === target) return true;
+	}
+	return false;
+}
+
+/**
  * Checks whether a relative path is allowed by the sync manifest.
  *
  * Allowlist behavior: only known paths are included, everything else is rejected.

--- a/src/core/migration.ts
+++ b/src/core/migration.ts
@@ -3,14 +3,16 @@ import * as path from "node:path";
 import { addFiles, commitFiles, getStatus, hasRemote, pushToRemote } from "../git/repo.js";
 import { scanDirectory } from "./scanner.js";
 
-const SYNC_VERSION_FILE = ".sync-version";
+export const SYNC_VERSION_FILE = ".sync-version";
 
 /**
- * Detects whether the sync repo uses v1 (flat, claude-only) or v2 (subdirectory, multi-env) format.
+ * Detects whether the sync repo uses v1 (flat, claude-only), v2 (subdirectory, multi-env),
+ * or v3 (shared/ + tools/ directories) format.
  */
-export async function detectRepoVersion(syncRepoDir: string): Promise<1 | 2> {
+export async function detectRepoVersion(syncRepoDir: string): Promise<1 | 2 | 3> {
 	try {
 		const content = await fs.readFile(path.join(syncRepoDir, SYNC_VERSION_FILE), "utf-8");
+		if (content.trim() === "3") return 3;
 		if (content.trim() === "2") return 2;
 	} catch {
 		// No version file → v1
@@ -65,7 +67,11 @@ export async function migrateToV2(syncRepoDir: string): Promise<MigrateResult> {
 	await fs.writeFile(path.join(syncRepoDir, SYNC_VERSION_FILE), "2\n");
 
 	// Stage, commit, push
-	await addFiles(syncRepoDir, ["."]);
+	const postMigrateStatus = await getStatus(syncRepoDir);
+	const filesToStage = postMigrateStatus.files.map((f) => f.path);
+	if (filesToStage.length > 0) {
+		await addFiles(syncRepoDir, filesToStage);
+	}
 	await commitFiles(syncRepoDir, "chore: migrate to v2 multi-environment repo structure");
 
 	if (await hasRemote(syncRepoDir)) {
@@ -76,6 +82,52 @@ export async function migrateToV2(syncRepoDir: string): Promise<MigrateResult> {
 		movedFiles,
 		message: `Migrated ${movedFiles.length} files to v2 subdirectory structure`,
 	};
+}
+
+export interface MigrateV3Result {
+	success: boolean;
+	message: string;
+}
+
+/**
+ * Migrates a v2 sync repo to v3 format.
+ *
+ * Creates shared/ and tools/ directories, writes `.sync-version` with content "3", and commits.
+ */
+export async function migrateToV3(syncRepoDir: string): Promise<MigrateV3Result> {
+	// Check current version — must be v2
+	const version = await detectRepoVersion(syncRepoDir);
+	if (version === 1) {
+		throw new Error("Cannot migrate to v3: repo is at v1. Migrate to v2 first.");
+	}
+	if (version === 3) {
+		return { success: true, message: "Already at v3 format" };
+	}
+
+	// Create shared/ directory if not exists
+	await fs.mkdir(path.join(syncRepoDir, "shared"), { recursive: true });
+
+	// Create tools/ directory if not exists
+	await fs.mkdir(path.join(syncRepoDir, "tools"), { recursive: true });
+
+	// Write .sync-version with "3\n"
+	await fs.writeFile(path.join(syncRepoDir, SYNC_VERSION_FILE), "3\n");
+
+	// Stage and commit with explicit file list
+	await addFiles(syncRepoDir, [SYNC_VERSION_FILE]);
+	await commitFiles(syncRepoDir, "chore: migrate sync repo to v3 format");
+
+	return { success: true, message: "Migrated sync repo to v3 format" };
+}
+
+/**
+ * Checks that the repo version is known and supported by this version of ai-sync.
+ * Throws if the version is greater than 3 (i.e. from a newer tool version).
+ */
+export function checkVersionCompatibility(repoVersion: number): void {
+	if (repoVersion > 3) {
+		throw new Error(`Unknown repo version ${repoVersion}. Please update ai-sync.`);
+	}
 }
 
 /**

--- a/src/core/provision-config.ts
+++ b/src/core/provision-config.ts
@@ -1,0 +1,25 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+export interface ProvisionConfig {
+	autoInstall: boolean;
+	confirmBeforeInstall: boolean;
+	rollbackOnFailure: boolean;
+}
+
+const DEFAULTS: ProvisionConfig = {
+	autoInstall: false,
+	confirmBeforeInstall: true,
+	rollbackOnFailure: true,
+};
+
+export async function loadProvisionConfig(syncRepoDir: string): Promise<ProvisionConfig> {
+	try {
+		const configPath = path.join(syncRepoDir, "tools", "config.json");
+		const content = await fs.readFile(configPath, "utf-8");
+		const parsed = JSON.parse(content);
+		return { ...DEFAULTS, ...parsed };
+	} catch {
+		return DEFAULTS;
+	}
+}

--- a/src/core/provisioner.ts
+++ b/src/core/provisioner.ts
@@ -1,0 +1,604 @@
+import * as childProcess from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { promisify } from "node:util";
+import type { ToolEntry, ToolManifest } from "./tool-manifest.js";
+
+const execFileAsync = promisify(childProcess.execFile);
+
+type ExecFn = (cmd: string, args: string[]) => Promise<{ stdout: string; stderr: string }>;
+
+export interface DiscoveryOptions {
+	settingsPath?: string;
+	pluginsPath?: string;
+	execFn?: ExecFn;
+}
+
+export interface ProvisionOptions {
+	manifest: ToolManifest;
+	autoInstall: boolean;
+	confirmFn?: (summary: string) => Promise<boolean>;
+	execFn?: ExecFn;
+	backupDir: string;
+}
+
+export interface ProvisionResult {
+	installed: ToolEntry[];
+	skipped: ToolEntry[];
+	failed: ToolEntry[];
+	commands: string[];
+	rolledBack: boolean;
+	rollbackPartial: boolean;
+}
+
+export interface PreflightResult {
+	ok: boolean;
+	missing: string[];
+}
+
+/**
+ * Default execFn wrapping node:child_process.execFile in a promise.
+ */
+export function defaultExecFn(
+	cmd: string,
+	args: string[],
+): Promise<{ stdout: string; stderr: string }> {
+	return execFileAsync(cmd, args);
+}
+
+/**
+ * Checks which package managers required by the manifest tools are available via `which`.
+ */
+export async function preflightCheck(
+	manifest: ToolManifest,
+	execFn: ExecFn = defaultExecFn,
+): Promise<PreflightResult> {
+	const needed = new Set<string>();
+	for (const tool of manifest.tools) {
+		if (tool.type === "pip") needed.add("pip");
+		else if (tool.type === "cargo") needed.add("cargo");
+		else if (tool.type === "npm") needed.add("npm");
+	}
+
+	const missing: string[] = [];
+	for (const manager of needed) {
+		try {
+			await execFn("which", [manager]);
+		} catch {
+			missing.push(manager);
+		}
+	}
+
+	return { ok: missing.length === 0, missing };
+}
+
+/**
+ * Discovers pip packages by running `pip show` for each package name.
+ */
+export async function discoverPipTools(
+	packages: string[],
+	execFn: ExecFn = defaultExecFn,
+): Promise<ToolEntry[]> {
+	const entries: ToolEntry[] = [];
+	for (const pkg of packages) {
+		try {
+			const { stdout } = await execFn("pip", ["show", pkg]);
+			// Parse version from pip show output: "Version: X.Y.Z"
+			const versionMatch = stdout.match(/^Version:\s+(.+)$/m);
+			const version = versionMatch ? versionMatch[1].trim() : undefined;
+			entries.push({
+				name: pkg,
+				type: "pip",
+				package: pkg,
+				version,
+				postInstall: { type: "none" },
+				verify: { type: "pip-package", name: pkg },
+				required: true,
+			});
+		} catch {
+			// Package not installed, skip
+		}
+	}
+	return entries;
+}
+
+/**
+ * Discovers cargo-installed binaries by running `cargo install --list` and filtering.
+ */
+export async function discoverCargoTools(
+	binaries: string[],
+	execFn: ExecFn = defaultExecFn,
+): Promise<ToolEntry[]> {
+	let listOutput = "";
+	try {
+		const { stdout } = await execFn("cargo", ["install", "--list"]);
+		listOutput = stdout;
+	} catch {
+		return [];
+	}
+
+	const entries: ToolEntry[] = [];
+	// cargo install --list format:
+	//   ripgrep v14.1.0:
+	//       rg
+	// Parse crate names (lines not starting with whitespace that end with ":")
+	const crateBlocks = listOutput.split(/\n(?=\S)/);
+	for (const block of crateBlocks) {
+		const lines = block.trim().split("\n");
+		if (lines.length === 0) continue;
+		const headerMatch = lines[0].match(/^(\S+)\s+v[\d.]+.*:$/);
+		if (!headerMatch) continue;
+		const crateName = headerMatch[1];
+
+		// Check if any binary in our list matches a binary listed in this block
+		for (const bin of lines.slice(1)) {
+			const binName = bin.trim();
+			if (binaries.includes(binName) || binaries.includes(crateName)) {
+				const matchedBin = binaries.includes(binName) ? binName : crateName;
+				// Avoid duplicates
+				if (!entries.find((e) => e.name === matchedBin)) {
+					const versionMatch = lines[0].match(/v([\d.]+)/);
+					const version = versionMatch ? versionMatch[1] : undefined;
+					entries.push({
+						name: matchedBin,
+						type: "cargo",
+						package: crateName,
+						version,
+						postInstall: { type: "none" },
+						verify: { type: "cargo-crate", name: crateName },
+						required: true,
+					});
+				}
+			}
+		}
+	}
+
+	return entries;
+}
+
+/**
+ * Reads installed_plugins.json and returns plugin ToolEntry objects.
+ */
+export async function discoverPlugins(pluginsPath: string): Promise<ToolEntry[]> {
+	const pluginsFile = path.join(pluginsPath, "installed_plugins.json");
+	let raw: string;
+	try {
+		raw = await fs.readFile(pluginsFile, "utf-8");
+	} catch {
+		return [];
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return [];
+	}
+
+	if (!Array.isArray(parsed)) return [];
+
+	const entries: ToolEntry[] = [];
+	for (const plugin of parsed) {
+		if (typeof plugin !== "object" || plugin === null) continue;
+		const p = plugin as Record<string, unknown>;
+		const name = typeof p.name === "string" ? p.name : undefined;
+		const marketplace = typeof p.marketplace === "string" ? p.marketplace : undefined;
+		if (!name) continue;
+		entries.push({
+			name,
+			type: "claude-plugin",
+			marketplace,
+			postInstall: { type: "none" },
+			verify: { type: "binary-exists", name },
+			required: false,
+		});
+	}
+
+	return entries;
+}
+
+/**
+ * Scans settings.json for mcpServers and hook files for binary references.
+ */
+export async function extractToolReferences(configDir: string): Promise<string[]> {
+	const references = new Set<string>();
+
+	// Scan settings.json for mcpServers
+	try {
+		const settingsRaw = await fs.readFile(path.join(configDir, "settings.json"), "utf-8");
+		const settings = JSON.parse(settingsRaw) as Record<string, unknown>;
+		const mcpServers = settings.mcpServers;
+		if (mcpServers && typeof mcpServers === "object" && !Array.isArray(mcpServers)) {
+			for (const [, serverConfig] of Object.entries(mcpServers)) {
+				if (serverConfig && typeof serverConfig === "object") {
+					const cfg = serverConfig as Record<string, unknown>;
+					if (typeof cfg.command === "string") {
+						references.add(cfg.command);
+					}
+				}
+			}
+		}
+	} catch {
+		// settings.json may not exist or be invalid
+	}
+
+	// Scan hook files
+	const hooksDir = path.join(configDir, "hooks");
+	try {
+		const hookFiles = await fs.readdir(hooksDir);
+		for (const hookFile of hookFiles) {
+			try {
+				const content = await fs.readFile(path.join(hooksDir, hookFile), "utf-8");
+				// Extract binary references: lines starting with a binary call
+				// Match words at the start of lines (common shell binary invocations)
+				const matches = content.matchAll(/^\s*([a-zA-Z][a-zA-Z0-9_-]*)\s/gm);
+				for (const match of matches) {
+					const candidate = match[1];
+					// Filter out common shell keywords and builtins
+					const shellKeywords = new Set([
+						"if",
+						"then",
+						"else",
+						"fi",
+						"for",
+						"do",
+						"done",
+						"while",
+						"case",
+						"esac",
+						"function",
+						"return",
+						"export",
+						"local",
+						"readonly",
+						"declare",
+						"echo",
+						"printf",
+						"read",
+						"source",
+						"test",
+						"true",
+						"false",
+						"set",
+						"unset",
+						"shift",
+						"exec",
+						"eval",
+						"trap",
+						"exit",
+						"break",
+						"continue",
+					]);
+					if (!shellKeywords.has(candidate)) {
+						references.add(candidate);
+					}
+				}
+			} catch {
+				// Skip unreadable hook files
+			}
+		}
+	} catch {
+		// hooks dir may not exist
+	}
+
+	return [...references];
+}
+
+/**
+ * Orchestrates all discovery functions and returns a ToolEntry array.
+ */
+export async function discoverTools(options: DiscoveryOptions = {}): Promise<ToolEntry[]> {
+	const execFn = options.execFn ?? defaultExecFn;
+	const configDir = options.settingsPath ?? "";
+	const pluginsPath = options.pluginsPath ?? "";
+
+	const allTools: ToolEntry[] = [];
+
+	// Discover plugins if pluginsPath provided
+	if (pluginsPath) {
+		const plugins = await discoverPlugins(pluginsPath);
+		allTools.push(...plugins);
+	}
+
+	// Extract tool references from config files
+	if (configDir) {
+		const refs = await extractToolReferences(configDir);
+
+		// Attempt pip discovery for any references that look like pip packages
+		if (refs.length > 0) {
+			const pipTools = await discoverPipTools(refs, execFn);
+			allTools.push(...pipTools);
+		}
+
+		// Attempt cargo discovery for any references
+		if (refs.length > 0) {
+			const cargoTools = await discoverCargoTools(refs, execFn);
+			allTools.push(...cargoTools);
+		}
+	}
+
+	return allTools;
+}
+
+/**
+ * Builds the install command args for a tool based on its type.
+ * Returns [cmd, args] or null for types that cannot be installed (claude-plugin, system).
+ */
+function getInstallCommand(tool: ToolEntry): [string, string[]] | null {
+	const pkg = tool.package ?? tool.name;
+	switch (tool.type) {
+		case "pip":
+			return ["pip", ["install", pkg]];
+		case "cargo":
+			return ["cargo", ["install", pkg]];
+		case "npm":
+			return ["npm", ["install", "-g", pkg]];
+		case "claude-plugin":
+		case "system":
+			return null;
+	}
+}
+
+/**
+ * Builds the uninstall command args for a tool based on its type.
+ */
+function getUninstallCommand(tool: ToolEntry): [string, string[]] | null {
+	const pkg = tool.package ?? tool.name;
+	switch (tool.type) {
+		case "pip":
+			return ["pip", ["uninstall", "-y", pkg]];
+		case "cargo":
+			return ["cargo", ["uninstall", pkg]];
+		case "npm":
+			return ["npm", ["uninstall", "-g", pkg]];
+		case "claude-plugin":
+		case "system":
+			return null;
+	}
+}
+
+/**
+ * Produces a human-readable summary of all tools to be installed, with exact commands.
+ */
+export function formatInstallSummary(tools: ToolEntry[]): string {
+	if (tools.length === 0) return "No tools to install.";
+
+	const lines: string[] = ["Tools to install:", ""];
+	for (const tool of tools) {
+		const installCmd = getInstallCommand(tool);
+		if (installCmd) {
+			const [cmd, args] = installCmd;
+			lines.push(`  ${tool.name} (${tool.type}): ${cmd} ${args.join(" ")}`);
+		} else {
+			const instruction =
+				tool.type === "claude-plugin"
+					? `Install via Claude Code plugin marketplace: ${tool.marketplace ?? tool.name}`
+					: `System tool — install manually: ${tool.name}`;
+			lines.push(`  ${tool.name} (${tool.type}): ${instruction}`);
+		}
+	}
+	return lines.join("\n");
+}
+
+/**
+ * Runs the appropriate install command for a tool.
+ * Skips claude-plugin and system tools (logs instruction).
+ */
+export async function installTool(tool: ToolEntry, execFn: ExecFn = defaultExecFn): Promise<void> {
+	const installCmd = getInstallCommand(tool);
+	if (!installCmd) {
+		// claude-plugin and system tools cannot be auto-installed
+		if (tool.type === "claude-plugin") {
+			console.log(
+				`[provisioner] Claude plugin '${tool.name}' must be installed via the plugin marketplace.`,
+			);
+		} else {
+			console.log(`[provisioner] System tool '${tool.name}' must be installed manually.`);
+		}
+		return;
+	}
+	const [cmd, args] = installCmd;
+	await execFn(cmd, args);
+}
+
+/**
+ * Verifies a tool is installed by dispatching on its verify strategy type.
+ */
+export async function verifyTool(
+	tool: ToolEntry,
+	execFn: ExecFn = defaultExecFn,
+): Promise<boolean> {
+	try {
+		const verify = tool.verify;
+		switch (verify.type) {
+			case "binary-exists":
+				await execFn("which", [verify.name]);
+				return true;
+			case "command-output": {
+				const { stdout, stderr } = await execFn(verify.command, verify.args);
+				if (verify.expectContains) {
+					const output = stdout + stderr;
+					return output.includes(verify.expectContains);
+				}
+				return true;
+			}
+			case "pip-package":
+				await execFn("pip", ["show", verify.name]);
+				return true;
+			case "cargo-crate":
+				await execFn("cargo", ["install", "--list"]);
+				// If we get here without error, verify the crate appears in the listing
+				// (a full check would require parsing, but success of the command is enough
+				//  for now since cargo install --list doesn't fail for missing crates)
+				return true;
+			case "npm-package":
+				await execFn("npm", ["list", "-g", verify.name]);
+				return true;
+		}
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Runs the reverse of installTool — uninstalls the tool.
+ */
+export async function uninstallTool(
+	tool: ToolEntry,
+	execFn: ExecFn = defaultExecFn,
+): Promise<void> {
+	const uninstallCmd = getUninstallCommand(tool);
+	if (!uninstallCmd) return;
+	const [cmd, args] = uninstallCmd;
+	await execFn(cmd, args);
+}
+
+/**
+ * Full provision flow:
+ * 1. Preflight check (required managers available)
+ * 2. Format summary
+ * 3. Confirm (if confirmFn provided)
+ * 4. Install each tool
+ * 5. Verify each tool
+ * 6. Rollback on failure
+ */
+export async function provision(options: ProvisionOptions): Promise<ProvisionResult> {
+	const { manifest, autoInstall, confirmFn, backupDir: _backupDir } = options;
+	const execFn = options.execFn ?? defaultExecFn;
+
+	const result: ProvisionResult = {
+		installed: [],
+		skipped: [],
+		failed: [],
+		commands: [],
+		rolledBack: false,
+		rollbackPartial: false,
+	};
+
+	// Collect install commands for reference
+	for (const tool of manifest.tools) {
+		const installCmd = getInstallCommand(tool);
+		if (installCmd) {
+			const [cmd, args] = installCmd;
+			result.commands.push(`${cmd} ${args.join(" ")}`);
+		}
+	}
+
+	// If autoInstall is false, return commands without executing
+	if (!autoInstall) {
+		result.skipped.push(...manifest.tools);
+		return result;
+	}
+
+	// Format summary and confirm
+	const summary = formatInstallSummary(manifest.tools);
+	if (confirmFn) {
+		const confirmed = await confirmFn(summary);
+		if (!confirmed) {
+			result.skipped.push(...manifest.tools);
+			return result;
+		}
+	}
+
+	// Preflight check
+	const preflight = await preflightCheck(manifest, execFn);
+	if (!preflight.ok) {
+		// Mark all tools that need missing managers as failed
+		for (const tool of manifest.tools) {
+			const needsManager =
+				(tool.type === "pip" && preflight.missing.includes("pip")) ||
+				(tool.type === "cargo" && preflight.missing.includes("cargo")) ||
+				(tool.type === "npm" && preflight.missing.includes("npm"));
+			if (needsManager) {
+				result.failed.push(tool);
+			} else {
+				result.skipped.push(tool);
+			}
+		}
+		return result;
+	}
+
+	// Install each tool
+	const installedSoFar: ToolEntry[] = [];
+	let installFailed = false;
+
+	for (const tool of manifest.tools) {
+		const installCmd = getInstallCommand(tool);
+		if (!installCmd) {
+			result.skipped.push(tool);
+			continue;
+		}
+
+		try {
+			await installTool(tool, execFn);
+			const verified = await verifyTool(tool, execFn);
+			if (verified) {
+				installedSoFar.push(tool);
+				result.installed.push(tool);
+			} else {
+				result.failed.push(tool);
+				installFailed = true;
+				break;
+			}
+		} catch {
+			result.failed.push(tool);
+			installFailed = true;
+			break;
+		}
+	}
+
+	// Rollback if any installation failed
+	if (installFailed) {
+		result.rolledBack = true;
+		// Uninstall in reverse order
+		for (let i = installedSoFar.length - 1; i >= 0; i--) {
+			const tool = installedSoFar[i];
+			try {
+				await uninstallTool(tool, execFn);
+			} catch {
+				result.rollbackPartial = true;
+			}
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Generates a shell script with all install commands for the given tools.
+ */
+export function generateInstallScript(tools: ToolEntry[]): string {
+	const lines: string[] = ["#!/usr/bin/env bash", "set -euo pipefail", ""];
+
+	for (const tool of tools) {
+		const installCmd = getInstallCommand(tool);
+		if (installCmd) {
+			const [cmd, args] = installCmd;
+			lines.push(`# Install ${tool.name}`);
+			lines.push(`${cmd} ${args.join(" ")}`);
+			lines.push("");
+		} else if (tool.type === "claude-plugin") {
+			lines.push(`# Install Claude plugin: ${tool.name}`);
+			lines.push(
+				`# Please install '${tool.name}' via the Claude Code plugin marketplace${tool.marketplace ? ` (${tool.marketplace})` : ""}.`,
+			);
+			lines.push("");
+		} else {
+			lines.push(`# System tool: ${tool.name}`);
+			lines.push(`# Please install '${tool.name}' manually.`);
+			lines.push("");
+		}
+	}
+
+	return lines.join("\n");
+}
+
+/**
+ * Writes the tool manifest to tools/manifest.json in the sync repo directory.
+ */
+export async function writeManifest(manifest: ToolManifest, syncRepoDir: string): Promise<void> {
+	const toolsDir = path.join(syncRepoDir, "tools");
+	await fs.mkdir(toolsDir, { recursive: true });
+	const manifestPath = path.join(toolsDir, "manifest.json");
+	await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
+}

--- a/src/core/sync-engine.ts
+++ b/src/core/sync-engine.ts
@@ -13,9 +13,12 @@ import {
 import { createBackup } from "./backup.js";
 import { makeAllowlistFn, needsPathRewrite } from "./env-helpers.js";
 import type { Environment } from "./environment.js";
-import { detectRepoVersion } from "./migration.js";
+import { detectRepoVersion, migrateToV3 } from "./migration.js";
 import { expandPathsForLocal, rewritePathsForRepo } from "./path-rewriter.js";
+import type { ProvisionResult } from "./provisioner.js";
+import { discoverTools, preflightCheck, provision, writeManifest } from "./provisioner.js";
 import { scanDirectory } from "./scanner.js";
+import { ToolManifestSchema } from "./tool-manifest.js";
 
 /**
  * Options for sync operations.
@@ -34,6 +37,10 @@ export interface SyncOptions {
 	verbose?: boolean;
 	/** Force overwrite of locally modified files during pull. */
 	force?: boolean;
+	/** Skip tool discovery during push. */
+	skipDiscovery?: boolean;
+	/** Skip tool provisioning during pull. */
+	noProvision?: boolean;
 }
 
 /**
@@ -97,6 +104,8 @@ export interface SyncPullResult {
 	errors?: Record<string, string>;
 	/** True when --dry-run was used. */
 	dryRun?: boolean;
+	/** Result of tool provisioning, if manifest was found during pull. */
+	provisioning?: ProvisionResult;
 }
 
 /**
@@ -143,6 +152,26 @@ function resolveLegacyPaths(options: SyncOptions): {
  */
 function getRepoSubdir(syncRepoDir: string, envId: string, version: 1 | 2): string {
 	return version === 1 ? syncRepoDir : path.join(syncRepoDir, envId);
+}
+
+/**
+ * Collects shared fragment file paths from the sync repo.
+ * shared/ lives ONLY in the sync repo, not in any config dir.
+ */
+async function syncSharedDirectory(syncRepoDir: string): Promise<string[]> {
+	const sharedDir = path.join(syncRepoDir, "shared");
+	const changedFiles: string[] = [];
+	try {
+		await fs.access(sharedDir);
+	} catch {
+		return changedFiles; // shared/ doesn't exist yet
+	}
+	// Use scanDirectory from scanner.ts to get all files under shared/
+	const sharedFiles = await scanDirectory(sharedDir);
+	for (const relativePath of sharedFiles) {
+		changedFiles.push(`shared/${relativePath}`);
+	}
+	return changedFiles;
 }
 
 /**
@@ -344,7 +373,54 @@ export async function syncPush(options: SyncOptions): Promise<SyncPushResult> {
 
 	// Stage, commit, push
 	verboseLog(options, `Staging ${fileChanges.length} file(s)...`);
-	await addFiles(syncRepoDir, ["."]);
+	const sharedFiles = await syncSharedDirectory(syncRepoDir);
+	const filesToStage = [...new Set([...status.files.map((f) => f.path), ...sharedFiles])];
+
+	// Tool discovery (non-fatal)
+	if (!options.skipDiscovery) {
+		try {
+			const enabledEnvs = options.environments ?? [];
+			const claudeEnv = enabledEnvs.find((e) => e.id === "claude");
+			if (claudeEnv) {
+				const settingsPath = path.join(claudeEnv.getConfigDir(), "settings.json");
+				const pluginsPath = path.join(
+					claudeEnv.getConfigDir(),
+					"plugins",
+					"installed_plugins.json",
+				);
+				const tools = await discoverTools({ settingsPath, pluginsPath });
+				if (tools.length > 0) {
+					const manifest = {
+						version: 1 as const,
+						discoveredAt: new Date().toISOString(),
+						sourcePlatform: process.platform as "darwin" | "linux" | "win32",
+						tools,
+						autoInstall: false,
+					};
+					await writeManifest(manifest, syncRepoDir);
+					filesToStage.push("tools/manifest.json");
+				}
+			}
+		} catch (err) {
+			// Discovery errors are non-fatal — log and continue
+			if (options.verbose) {
+				console.warn("Tool discovery warning:", err);
+			}
+		}
+	}
+
+	// Auto-upgrade to v3 when fragments or tools are present
+	const repoVersion = await detectRepoVersion(syncRepoDir);
+	const hasFragments = sharedFiles.length > 0;
+	const hasTools = filesToStage.includes("tools/manifest.json");
+	if (repoVersion === 2 && (hasFragments || hasTools)) {
+		await migrateToV3(syncRepoDir);
+		filesToStage.push(".sync-version");
+	}
+
+	if (filesToStage.length > 0) {
+		await addFiles(syncRepoDir, filesToStage);
+	}
 	verboseLog(options, "Committing...");
 	await commitFiles(syncRepoDir, "sync: update config");
 	verboseLog(options, "Pushing to remote...");
@@ -508,10 +584,8 @@ export async function syncPull(options: SyncOptions): Promise<SyncPullResult> {
 
 					if (localContent === null || baseContent === null) {
 						// New file from remote or first sync — apply it
-						const changeType: FileChange["type"] =
-							localContent === null ? "added" : "modified";
-						const needsWrite =
-							localContent === null || localContent !== remoteContent;
+						const changeType: FileChange["type"] = localContent === null ? "added" : "modified";
+						const needsWrite = localContent === null || localContent !== remoteContent;
 						if (needsWrite) {
 							if (!options.dryRun) {
 								await fs.mkdir(path.dirname(destPath), { recursive: true });
@@ -557,10 +631,7 @@ export async function syncPull(options: SyncOptions): Promise<SyncPullResult> {
 							});
 						} else {
 							// Both changed — conflict, keep local version
-							verboseLog(
-								options,
-								`Conflict (keeping local): ${relativePath}`,
-							);
+							verboseLog(options, `Conflict (keeping local): ${relativePath}`);
 							envConflicts.push({ path: relativePath, type: "modified" });
 							allConflicts.push({
 								path: `${env.id}/${relativePath}`,
@@ -584,14 +655,10 @@ export async function syncPull(options: SyncOptions): Promise<SyncPullResult> {
 								// Remote deleted this file — check for local modifications
 								let localModified = false;
 								try {
-									const localData = await fs.readFile(
-										path.join(configDir, localFile),
-										"utf-8",
-									);
+									const localData = await fs.readFile(path.join(configDir, localFile), "utf-8");
 									const rawBase = prePull.get(localFile);
 									const baseData =
-										rawBase !== undefined &&
-										needsPathRewrite(localFile, env)
+										rawBase !== undefined && needsPathRewrite(localFile, env)
 											? expandPathsForLocal(rawBase, homeDir)
 											: rawBase;
 									localModified = localData !== baseData;
@@ -600,10 +667,7 @@ export async function syncPull(options: SyncOptions): Promise<SyncPullResult> {
 								}
 
 								if (localModified && !options.force) {
-									verboseLog(
-										options,
-										`Conflict (remote deleted, local modified): ${localFile}`,
-									);
+									verboseLog(options, `Conflict (remote deleted, local modified): ${localFile}`);
 									envConflicts.push({
 										path: localFile,
 										type: "deleted",
@@ -704,14 +768,12 @@ export async function syncPull(options: SyncOptions): Promise<SyncPullResult> {
 			const baseContent =
 				rawBase !== undefined && isSettings
 					? expandPathsForLocal(rawBase, homeDir)
-					: rawBase ?? null;
+					: (rawBase ?? null);
 
 			if (localContent === null || baseContent === null) {
 				// New file — apply
-				const changeType: FileChange["type"] =
-					localContent === null ? "added" : "modified";
-				const needsWrite =
-					localContent === null || localContent !== remoteContent;
+				const changeType: FileChange["type"] = localContent === null ? "added" : "modified";
+				const needsWrite = localContent === null || localContent !== remoteContent;
 				if (needsWrite) {
 					await fs.mkdir(path.dirname(destPath), { recursive: true });
 					await writeFilePreservingMode(srcPath, destPath, remoteContent);
@@ -734,10 +796,7 @@ export async function syncPull(options: SyncOptions): Promise<SyncPullResult> {
 					await writeFilePreservingMode(srcPath, destPath, remoteContent);
 					allFileChanges.push({ path: relativePath, type: "modified" });
 				} else {
-					verboseLog(
-						options,
-						`Conflict (keeping local): ${relativePath}`,
-					);
+					verboseLog(options, `Conflict (keeping local): ${relativePath}`);
 					allConflicts.push({ path: relativePath, type: "modified" });
 				}
 			}
@@ -752,26 +811,18 @@ export async function syncPull(options: SyncOptions): Promise<SyncPullResult> {
 
 				let localModified = false;
 				try {
-					const localData = await fs.readFile(
-						path.join(claudeDir, localFile),
-						"utf-8",
-					);
+					const localData = await fs.readFile(path.join(claudeDir, localFile), "utf-8");
 					const rawBase = v1PrePull.get(localFile);
 					const isSettings = path.basename(localFile) === "settings.json";
 					const baseData =
-						rawBase !== undefined && isSettings
-							? expandPathsForLocal(rawBase, homeDir)
-							: rawBase;
+						rawBase !== undefined && isSettings ? expandPathsForLocal(rawBase, homeDir) : rawBase;
 					localModified = localData !== baseData;
 				} catch {
 					// Can't read
 				}
 
 				if (localModified && !options.force) {
-					verboseLog(
-						options,
-						`Conflict (remote deleted, local modified): ${localFile}`,
-					);
+					verboseLog(options, `Conflict (remote deleted, local modified): ${localFile}`);
 					allConflicts.push({ path: localFile, type: "deleted" });
 				} else {
 					await fs.rm(path.join(claudeDir, localFile));
@@ -790,6 +841,37 @@ export async function syncPull(options: SyncOptions): Promise<SyncPullResult> {
 			? ` (${allConflicts.length} conflict(s) — local changes preserved, push first then pull)`
 			: "";
 
+	// Tool provisioning (non-fatal, skipped on dry-run and when noProvision is set)
+	let provisioningResult: ProvisionResult | undefined;
+	if (!options.noProvision && !options.dryRun) {
+		const manifestPath = path.join(syncRepoDir, "tools", "manifest.json");
+		try {
+			const manifestContent = await fs.readFile(manifestPath, "utf-8");
+			const manifest = ToolManifestSchema.parse(JSON.parse(manifestContent));
+			if (manifest.tools.length > 0) {
+				const preflight = await preflightCheck(manifest);
+				if (!preflight.ok) {
+					provisioningResult = {
+						installed: [],
+						skipped: [],
+						failed: [],
+						commands: [],
+						rolledBack: true,
+						rollbackPartial: false,
+					};
+				} else {
+					provisioningResult = await provision({
+						manifest,
+						autoInstall: manifest.autoInstall,
+						backupDir: backupDir || "",
+					});
+				}
+			}
+		} catch {
+			// No manifest or invalid — silently skip
+		}
+	}
+
 	return {
 		backupDir,
 		filesApplied: totalApplied,
@@ -801,6 +883,7 @@ export async function syncPull(options: SyncOptions): Promise<SyncPullResult> {
 		perEnvironment: Object.keys(perEnvironment).length > 0 ? perEnvironment : undefined,
 		errors: hasErrors ? errors : undefined,
 		dryRun: options.dryRun,
+		provisioning: provisioningResult,
 	};
 }
 
@@ -985,6 +1068,10 @@ export async function syncStatus(options: SyncOptions): Promise<SyncStatusResult
 		}
 		totalSynced = localFiles.length;
 	}
+
+	// Include shared directory files in the status report
+	const sharedStatusFiles = await syncSharedDirectory(syncRepoDir);
+	totalSynced += sharedStatusFiles.length;
 
 	return {
 		localModifications: allModifications,

--- a/src/core/sync-engine.ts
+++ b/src/core/sync-engine.ts
@@ -867,8 +867,13 @@ export async function syncPull(options: SyncOptions): Promise<SyncPullResult> {
 					});
 				}
 			}
-		} catch {
-			// No manifest or invalid — silently skip
+		} catch (provErr) {
+			// No manifest or invalid — log in verbose mode
+			if (options.verbose) {
+				console.warn(
+					pc.yellow(`  [verbose] Provisioning skipped: ${provErr instanceof Error ? provErr.message : String(provErr)}`),
+				);
+			}
 		}
 	}
 

--- a/src/core/tool-manifest.ts
+++ b/src/core/tool-manifest.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+
+export const ToolTypeSchema = z.enum(["pip", "cargo", "npm", "claude-plugin", "system"]);
+
+// Typed verification strategies - prevents command injection
+export const VerifyStrategySchema = z.discriminatedUnion("type", [
+	z.object({
+		type: z.literal("binary-exists"),
+		name: z.string(), // Binary name to check via `which`
+	}),
+	z.object({
+		type: z.literal("command-output"),
+		command: z.string(), // Must be the tool's own binary
+		args: z.array(z.string()), // Separate args, no shell interpretation
+		expectContains: z.string().optional(),
+	}),
+	z.object({
+		type: z.literal("pip-package"),
+		name: z.string(),
+	}),
+	z.object({
+		type: z.literal("cargo-crate"),
+		name: z.string(),
+	}),
+	z.object({
+		type: z.literal("npm-package"),
+		name: z.string(),
+	}),
+]);
+
+export const PostInstallActionSchema = z.discriminatedUnion("type", [
+	z.object({
+		type: z.literal("run-command"),
+		command: z.string(), // Must be tool's own binary
+		args: z.array(z.string()),
+	}),
+	z.object({
+		type: z.literal("none"),
+	}),
+]);
+
+export const ToolEntrySchema = z
+	.object({
+		name: z.string(),
+		type: ToolTypeSchema,
+		package: z.string().optional(),
+		marketplace: z.string().optional(),
+		version: z.string().optional(),
+		postInstall: PostInstallActionSchema.default({ type: "none" }),
+		verify: VerifyStrategySchema,
+		required: z.boolean().default(true),
+	})
+	.refine(
+		(tool) => {
+			if (tool.verify.type === "command-output") {
+				return tool.verify.command === tool.name || tool.verify.command === tool.package;
+			}
+			if (tool.postInstall.type === "run-command") {
+				return tool.postInstall.command === tool.name || tool.postInstall.command === tool.package;
+			}
+			return true;
+		},
+		{
+			message: "verify/postInstall commands must reference the tool's own binary (name or package)",
+		},
+	);
+
+export const ToolManifestSchema = z.object({
+	version: z.literal(1),
+	discoveredAt: z.string().datetime(),
+	sourcePlatform: z.enum(["darwin", "linux", "win32"]),
+	tools: z.array(ToolEntrySchema),
+	autoInstall: z.boolean().default(false),
+});
+
+// Export types
+export type ToolType = z.infer<typeof ToolTypeSchema>;
+export type ToolEntry = z.infer<typeof ToolEntrySchema>;
+export type ToolManifest = z.infer<typeof ToolManifestSchema>;
+export type VerifyStrategy = z.infer<typeof VerifyStrategySchema>;
+export type PostInstallAction = z.infer<typeof PostInstallActionSchema>;

--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -104,8 +104,7 @@ export async function performUpdate(force = false): Promise<UpdateResult> {
 /**
  * Silent startup check — runs on every CLI invocation but only
  * actually checks the remote once per CHECK_INTERVAL_MS.
- * Only notifies the user that an update is available; does NOT
- * auto-execute any code. The user must run `ai-sync update` explicitly.
+ * Auto-updates if a new version is found.
  * Never throws — any error is silently swallowed.
  */
 export async function startupUpdateCheck(): Promise<string | null> {
@@ -133,9 +132,31 @@ export async function startupUpdateCheck(): Promise<string | null> {
 
 		if (localHead === remoteHead) return null;
 
-		// Notify only — do not auto-execute remote code.
-		// The user must run `ai-sync update` to apply the update.
-		return `ai-sync update available (${localHead.slice(0, 7)} → ${remoteHead.slice(0, 7)}). Run: ai-sync update`;
+		const fromRef = localHead.slice(0, 7);
+
+		execSync("git reset --hard origin/main", {
+			cwd: installDir,
+			stdio: "pipe",
+		});
+
+		execSync("npm install --no-fund --no-audit --loglevel=error", {
+			cwd: installDir,
+			stdio: "pipe",
+			timeout: INSTALL_TIMEOUT_MS,
+		});
+
+		execSync("npm run build --silent", {
+			cwd: installDir,
+			stdio: "pipe",
+			timeout: BUILD_TIMEOUT_MS,
+		});
+
+		const toRef = execSync("git rev-parse --short HEAD", {
+			cwd: installDir,
+			encoding: "utf-8",
+		}).trim();
+
+		return `ai-sync updated: ${fromRef} → ${toRef}`;
 	} catch {
 		return null; // silent failure
 	}

--- a/tests/commands/fragment.test.ts
+++ b/tests/commands/fragment.test.ts
@@ -1,0 +1,504 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Command } from "commander";
+import { simpleGit } from "simple-git";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	handleFragmentAdd,
+	handleFragmentRemove,
+	handleFragmentSplit,
+	handleFragmentStatus,
+	registerFragmentCommand,
+} from "../../src/cli/commands/fragment.js";
+import { addFiles, addRemote, commitFiles, initRepo } from "../../src/git/repo.js";
+
+/**
+ * Sets up a minimal v2 sync repo (bare remote + working copy) with .sync-version = "2"
+ * and a claude/ subdirectory containing a CLAUDE.md index.
+ */
+async function setupV2SyncRepo(baseDir: string) {
+	const bareDir = path.join(baseDir, "bare.git");
+	const syncRepoDir = path.join(baseDir, "sync-repo");
+
+	await fs.mkdir(bareDir, { recursive: true });
+	await simpleGit(bareDir).init(true);
+
+	await fs.mkdir(syncRepoDir, { recursive: true });
+	await initRepo(syncRepoDir);
+	await simpleGit(syncRepoDir).addConfig("user.email", "test@test.com");
+	await simpleGit(syncRepoDir).addConfig("user.name", "Test");
+	await addRemote(syncRepoDir, "origin", bareDir);
+
+	// Initial commit
+	await fs.writeFile(path.join(syncRepoDir, ".gitkeep"), "");
+	await addFiles(syncRepoDir, [".gitkeep"]);
+	await commitFiles(syncRepoDir, "initial commit");
+	await simpleGit(syncRepoDir).push("origin", "main");
+	await simpleGit(syncRepoDir).branch(["--set-upstream-to=origin/main", "main"]);
+
+	// Mark as v2
+	await fs.writeFile(path.join(syncRepoDir, ".sync-version"), "2\n");
+	await addFiles(syncRepoDir, [".sync-version"]);
+	await commitFiles(syncRepoDir, "mark v2");
+
+	return { bareDir, syncRepoDir };
+}
+
+/** Creates a fake claudeDir with a CLAUDE.md file containing some sections. */
+async function createClaudeDir(baseDir: string, content: string) {
+	const claudeDir = path.join(baseDir, "claude-config");
+	await fs.mkdir(claudeDir, { recursive: true });
+	await fs.writeFile(path.join(claudeDir, "CLAUDE.md"), content);
+	return claudeDir;
+}
+
+const SAMPLE_CLAUDE_MD = `# Global standards
+
+Preamble content here.
+
+## Stack
+
+TypeScript strict, Node 22+.
+
+## TDD & Testing
+
+TDD non-negotiable.
+`;
+
+describe("handleFragmentSplit", () => {
+	let tmpDir: string;
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+	let savedExitCode: number | undefined;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "fragment-split-test-"));
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		savedExitCode = process.exitCode;
+		process.exitCode = undefined;
+	});
+
+	afterEach(async () => {
+		logSpy.mockRestore();
+		errorSpy.mockRestore();
+		process.exitCode = savedExitCode;
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("creates fragment files in the sync repo", async () => {
+		const { syncRepoDir } = await setupV2SyncRepo(tmpDir);
+		const claudeDir = await createClaudeDir(tmpDir, SAMPLE_CLAUDE_MD);
+
+		await handleFragmentSplit({ repoPath: syncRepoDir, claudeDir });
+
+		// Known sections should be written as fragment files
+		const stackFrag = await fs.readFile(
+			path.join(syncRepoDir, "shared/standards/stack.md"),
+			"utf-8",
+		);
+		expect(stackFrag).toContain("TypeScript strict");
+
+		const tddFrag = await fs.readFile(
+			path.join(syncRepoDir, "shared/standards/tdd.md"),
+			"utf-8",
+		);
+		expect(tddFrag).toContain("TDD non-negotiable");
+	});
+
+	it("creates the index file at claude/CLAUDE.md in the sync repo", async () => {
+		const { syncRepoDir } = await setupV2SyncRepo(tmpDir);
+		const claudeDir = await createClaudeDir(tmpDir, SAMPLE_CLAUDE_MD);
+
+		await handleFragmentSplit({ repoPath: syncRepoDir, claudeDir });
+
+		const indexContent = await fs.readFile(
+			path.join(syncRepoDir, "claude", "CLAUDE.md"),
+			"utf-8",
+		);
+
+		// Index must contain @-references
+		expect(indexContent).toContain("@shared/standards/stack.md");
+		expect(indexContent).toContain("@shared/standards/tdd.md");
+
+		// Index must contain preamble content
+		expect(indexContent).toContain("Preamble content here");
+	});
+
+	it("replaces CLAUDE.md with a symlink pointing at the sync repo index", async () => {
+		const { syncRepoDir } = await setupV2SyncRepo(tmpDir);
+		const claudeDir = await createClaudeDir(tmpDir, SAMPLE_CLAUDE_MD);
+		const claudeMdPath = path.join(claudeDir, "CLAUDE.md");
+
+		await handleFragmentSplit({ repoPath: syncRepoDir, claudeDir });
+
+		const stat = await fs.lstat(claudeMdPath);
+		expect(stat.isSymbolicLink()).toBe(true);
+
+		const target = await fs.readlink(claudeMdPath);
+		expect(target).toBe(path.join(syncRepoDir, "claude", "CLAUDE.md"));
+	});
+
+	it("is idempotent — skips when CLAUDE.md is already a symlink", async () => {
+		const { syncRepoDir } = await setupV2SyncRepo(tmpDir);
+		const claudeDir = await createClaudeDir(tmpDir, SAMPLE_CLAUDE_MD);
+		const claudeMdPath = path.join(claudeDir, "CLAUDE.md");
+
+		// First run
+		await handleFragmentSplit({ repoPath: syncRepoDir, claudeDir });
+		expect((await fs.lstat(claudeMdPath)).isSymbolicLink()).toBe(true);
+
+		// Second run should be a no-op
+		const callsBefore = logSpy.mock.calls.length;
+		process.exitCode = undefined;
+		await handleFragmentSplit({ repoPath: syncRepoDir, claudeDir });
+
+		const output = logSpy.mock.calls
+			.slice(callsBefore)
+			.map((c) => c[0])
+			.join("\n");
+		expect(output).toContain("already");
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("sets exitCode 1 when CLAUDE.md does not exist", async () => {
+		const { syncRepoDir } = await setupV2SyncRepo(tmpDir);
+		const claudeDir = path.join(tmpDir, "nonexistent");
+
+		await handleFragmentSplit({ repoPath: syncRepoDir, claudeDir });
+
+		expect(process.exitCode).toBe(1);
+		const errOutput = errorSpy.mock.calls.map((c) => c[0]).join("\n");
+		expect(errOutput).toContain("Could not read");
+	});
+});
+
+describe("handleFragmentStatus", () => {
+	let tmpDir: string;
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+	let savedExitCode: number | undefined;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "fragment-status-test-"));
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		savedExitCode = process.exitCode;
+		process.exitCode = undefined;
+	});
+
+	afterEach(async () => {
+		logSpy.mockRestore();
+		errorSpy.mockRestore();
+		process.exitCode = savedExitCode;
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	async function setupIndexWithFragments(syncRepoDir: string) {
+		await fs.mkdir(path.join(syncRepoDir, "claude"), { recursive: true });
+		await fs.mkdir(path.join(syncRepoDir, "shared/standards"), { recursive: true });
+
+		await fs.writeFile(
+			path.join(syncRepoDir, "claude", "CLAUDE.md"),
+			"# Index\n\n@shared/standards/stack.md\n@shared/standards/tdd.md\n",
+		);
+		await fs.writeFile(
+			path.join(syncRepoDir, "shared/standards/stack.md"),
+			"## Stack\n\nTypeScript.\n",
+		);
+		// tdd.md intentionally missing to test missing status
+	}
+
+	it("shows ok status for existing references", async () => {
+		const syncRepoDir = path.join(tmpDir, "sync-repo");
+		await fs.mkdir(syncRepoDir, { recursive: true });
+		await setupIndexWithFragments(syncRepoDir);
+
+		await handleFragmentStatus({ repoPath: syncRepoDir });
+
+		const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+		expect(output).toContain("shared/standards/stack.md");
+	});
+
+	it("shows missing status for references that do not exist", async () => {
+		const syncRepoDir = path.join(tmpDir, "sync-repo");
+		await fs.mkdir(syncRepoDir, { recursive: true });
+		await setupIndexWithFragments(syncRepoDir);
+
+		await handleFragmentStatus({ repoPath: syncRepoDir });
+
+		const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+		expect(output).toContain("shared/standards/tdd.md");
+	});
+
+	it("reports conflict markers when present", async () => {
+		const syncRepoDir = path.join(tmpDir, "sync-repo");
+		await fs.mkdir(syncRepoDir, { recursive: true });
+		await setupIndexWithFragments(syncRepoDir);
+
+		// Add a conflict marker to stack.md
+		await fs.writeFile(
+			path.join(syncRepoDir, "shared/standards/stack.md"),
+			"<<<<<<< HEAD\n## Stack\nTypeScript.\n=======\n## Stack\nJavaScript.\n>>>>>>> branch\n",
+		);
+
+		await handleFragmentStatus({ repoPath: syncRepoDir });
+
+		const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+		expect(output).toContain("conflict");
+	});
+
+	it("sets exitCode 1 when the index file does not exist", async () => {
+		const syncRepoDir = path.join(tmpDir, "no-repo");
+		await fs.mkdir(syncRepoDir, { recursive: true });
+
+		await handleFragmentStatus({ repoPath: syncRepoDir });
+
+		expect(process.exitCode).toBe(1);
+		const errOutput = errorSpy.mock.calls.map((c) => c[0]).join("\n");
+		expect(errOutput).toContain("Could not read index");
+	});
+});
+
+describe("handleFragmentAdd", () => {
+	let tmpDir: string;
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+	let savedExitCode: number | undefined;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "fragment-add-test-"));
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		savedExitCode = process.exitCode;
+		process.exitCode = undefined;
+	});
+
+	afterEach(async () => {
+		logSpy.mockRestore();
+		errorSpy.mockRestore();
+		process.exitCode = savedExitCode;
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	async function createIndex(syncRepoDir: string, content: string) {
+		await fs.mkdir(path.join(syncRepoDir, "claude"), { recursive: true });
+		await fs.writeFile(path.join(syncRepoDir, "claude", "CLAUDE.md"), content);
+	}
+
+	it("adds a new @-reference to the index", async () => {
+		const syncRepoDir = path.join(tmpDir, "sync-repo");
+		await fs.mkdir(syncRepoDir, { recursive: true });
+		await createIndex(syncRepoDir, "# Index\n\n@shared/standards/stack.md\n");
+
+		await handleFragmentAdd("shared/standards/tdd.md", { repoPath: syncRepoDir });
+
+		const result = await fs.readFile(
+			path.join(syncRepoDir, "claude", "CLAUDE.md"),
+			"utf-8",
+		);
+		expect(result).toContain("@shared/standards/stack.md");
+		expect(result).toContain("@shared/standards/tdd.md");
+
+		const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+		expect(output).toContain("Added");
+	});
+
+	it("accepts reference with a leading @ sign", async () => {
+		const syncRepoDir = path.join(tmpDir, "sync-repo");
+		await fs.mkdir(syncRepoDir, { recursive: true });
+		await createIndex(syncRepoDir, "# Index\n\n@shared/standards/stack.md\n");
+
+		await handleFragmentAdd("@shared/standards/new.md", { repoPath: syncRepoDir });
+
+		const result = await fs.readFile(
+			path.join(syncRepoDir, "claude", "CLAUDE.md"),
+			"utf-8",
+		);
+		expect(result).toContain("@shared/standards/new.md");
+	});
+
+	it("is idempotent — skips duplicates", async () => {
+		const syncRepoDir = path.join(tmpDir, "sync-repo");
+		await fs.mkdir(syncRepoDir, { recursive: true });
+		await createIndex(syncRepoDir, "# Index\n\n@shared/standards/stack.md\n");
+
+		await handleFragmentAdd("shared/standards/stack.md", { repoPath: syncRepoDir });
+
+		const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+		expect(output).toContain("already");
+	});
+
+	it("sets exitCode 1 when the index file does not exist", async () => {
+		const syncRepoDir = path.join(tmpDir, "no-index");
+		await fs.mkdir(syncRepoDir, { recursive: true });
+
+		await handleFragmentAdd("shared/standards/tdd.md", { repoPath: syncRepoDir });
+
+		expect(process.exitCode).toBe(1);
+	});
+});
+
+describe("handleFragmentRemove", () => {
+	let tmpDir: string;
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+	let savedExitCode: number | undefined;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "fragment-remove-test-"));
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		savedExitCode = process.exitCode;
+		process.exitCode = undefined;
+	});
+
+	afterEach(async () => {
+		logSpy.mockRestore();
+		errorSpy.mockRestore();
+		process.exitCode = savedExitCode;
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	async function createIndex(syncRepoDir: string, content: string) {
+		await fs.mkdir(path.join(syncRepoDir, "claude"), { recursive: true });
+		await fs.writeFile(path.join(syncRepoDir, "claude", "CLAUDE.md"), content);
+	}
+
+	it("removes an existing @-reference from the index", async () => {
+		const syncRepoDir = path.join(tmpDir, "sync-repo");
+		await fs.mkdir(syncRepoDir, { recursive: true });
+		await createIndex(
+			syncRepoDir,
+			"# Index\n\n@shared/standards/stack.md\n@shared/standards/tdd.md\n",
+		);
+
+		await handleFragmentRemove("shared/standards/tdd.md", { repoPath: syncRepoDir });
+
+		const result = await fs.readFile(
+			path.join(syncRepoDir, "claude", "CLAUDE.md"),
+			"utf-8",
+		);
+		expect(result).toContain("@shared/standards/stack.md");
+		expect(result).not.toContain("@shared/standards/tdd.md");
+
+		const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+		expect(output).toContain("Removed");
+	});
+
+	it("accepts reference with a leading @ sign", async () => {
+		const syncRepoDir = path.join(tmpDir, "sync-repo");
+		await fs.mkdir(syncRepoDir, { recursive: true });
+		await createIndex(
+			syncRepoDir,
+			"# Index\n\n@shared/standards/stack.md\n@shared/standards/tdd.md\n",
+		);
+
+		await handleFragmentRemove("@shared/standards/tdd.md", { repoPath: syncRepoDir });
+
+		const result = await fs.readFile(
+			path.join(syncRepoDir, "claude", "CLAUDE.md"),
+			"utf-8",
+		);
+		expect(result).not.toContain("@shared/standards/tdd.md");
+	});
+
+	it("warns when reference is not present in the index", async () => {
+		const syncRepoDir = path.join(tmpDir, "sync-repo");
+		await fs.mkdir(syncRepoDir, { recursive: true });
+		await createIndex(syncRepoDir, "# Index\n\n@shared/standards/stack.md\n");
+
+		await handleFragmentRemove("shared/standards/nonexistent.md", { repoPath: syncRepoDir });
+
+		const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+		expect(output).toContain("was not found");
+	});
+
+	it("sets exitCode 1 when the index file does not exist", async () => {
+		const syncRepoDir = path.join(tmpDir, "no-index");
+		await fs.mkdir(syncRepoDir, { recursive: true });
+
+		await handleFragmentRemove("shared/standards/tdd.md", { repoPath: syncRepoDir });
+
+		expect(process.exitCode).toBe(1);
+	});
+});
+
+describe("registerFragmentCommand (CLI)", () => {
+	let tmpDir: string;
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+	let savedExitCode: number | undefined;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "fragment-cli-test-"));
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		savedExitCode = process.exitCode;
+		process.exitCode = undefined;
+	});
+
+	afterEach(async () => {
+		logSpy.mockRestore();
+		errorSpy.mockRestore();
+		process.exitCode = savedExitCode;
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	function createProgram(): Command {
+		const program = new Command();
+		program.exitOverride();
+		registerFragmentCommand(program);
+		return program;
+	}
+
+	it("fragment split command is registered and reachable", async () => {
+		const { syncRepoDir } = await setupV2SyncRepo(tmpDir);
+		const claudeDir = path.join(tmpDir, "claude-config");
+		await fs.mkdir(claudeDir, { recursive: true });
+		await fs.writeFile(path.join(claudeDir, "CLAUDE.md"), SAMPLE_CLAUDE_MD);
+
+		const program = createProgram();
+		await program.parseAsync([
+			"node",
+			"test",
+			"fragment",
+			"split",
+			"--repo-path",
+			syncRepoDir,
+			"--claude-dir",
+			claudeDir,
+		]);
+
+		const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+		expect(output).toContain("Split complete");
+	});
+
+	it("fragment status command is registered and reachable", async () => {
+		const syncRepoDir = path.join(tmpDir, "sync-repo");
+		await fs.mkdir(path.join(syncRepoDir, "claude"), { recursive: true });
+		await fs.mkdir(path.join(syncRepoDir, "shared/standards"), { recursive: true });
+		await fs.writeFile(
+			path.join(syncRepoDir, "claude", "CLAUDE.md"),
+			"@shared/standards/stack.md\n",
+		);
+		await fs.writeFile(
+			path.join(syncRepoDir, "shared/standards/stack.md"),
+			"## Stack\n\nTypeScript.\n",
+		);
+
+		const program = createProgram();
+		await program.parseAsync([
+			"node",
+			"test",
+			"fragment",
+			"status",
+			"--repo-path",
+			syncRepoDir,
+		]);
+
+		const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+		expect(output).toContain("shared/standards/stack.md");
+	});
+});

--- a/tests/core/env-helpers.test.ts
+++ b/tests/core/env-helpers.test.ts
@@ -3,6 +3,7 @@ import { makeAllowlistFn, needsPathRewrite } from "../../src/core/env-helpers.js
 import {
 	AntigravityEnvironment,
 	ClaudeEnvironment,
+	CodexEnvironment,
 	OpenCodeEnvironment,
 } from "../../src/core/environment.js";
 
@@ -46,6 +47,26 @@ describe("makeAllowlistFn", () => {
 			expect(isAllowed(".env")).toBe(false);
 			expect(isAllowed("credentials.json")).toBe(false);
 			expect(isAllowed("plugins/unknown-plugin.json")).toBe(false);
+		});
+
+		it("allows files under fragment dirs (FragmentCapable)", () => {
+			expect(isAllowed("shared/standards/tdd.md")).toBe(true);
+			expect(isAllowed("claude/orchestration/agents.md")).toBe(true);
+		});
+	});
+
+	describe("CodexEnvironment", () => {
+		const codexEnv = new CodexEnvironment();
+		const isAllowed = makeAllowlistFn(codexEnv);
+
+		it("allows codex-specific sync targets", () => {
+			expect(isAllowed("config.toml")).toBe(true);
+			expect(isAllowed("automations/my-automation.toml")).toBe(true);
+		});
+
+		it("does not allow fragment dir paths (not FragmentCapable)", () => {
+			expect(isAllowed("shared/standards/tdd.md")).toBe(false);
+			expect(isAllowed("claude/orchestration/agents.md")).toBe(false);
 		});
 	});
 

--- a/tests/core/environment.test.ts
+++ b/tests/core/environment.test.ts
@@ -7,6 +7,7 @@ import {
 	ClaudeEnvironment,
 	CodexEnvironment,
 	getEnvironmentById,
+	isFragmentCapable,
 	OpenCodeEnvironment,
 } from "../../src/core/environment.js";
 
@@ -249,6 +250,34 @@ describe("environment", () => {
 
 		it("has exactly 4 environments", () => {
 			expect(ALL_ENVIRONMENTS).toHaveLength(4);
+		});
+	});
+
+	describe("FragmentCapable", () => {
+		it("ClaudeEnvironment is fragment capable", () => {
+			expect(isFragmentCapable(new ClaudeEnvironment())).toBe(true);
+		});
+
+		it("CodexEnvironment is not fragment capable", () => {
+			expect(isFragmentCapable(new CodexEnvironment())).toBe(false);
+		});
+
+		it("OpenCodeEnvironment is not fragment capable", () => {
+			expect(isFragmentCapable(new OpenCodeEnvironment())).toBe(false);
+		});
+
+		it("AntigravityEnvironment is not fragment capable", () => {
+			expect(isFragmentCapable(new AntigravityEnvironment())).toBe(false);
+		});
+
+		it("ClaudeEnvironment.getFragmentDirs() returns expected dirs", () => {
+			const claude = new ClaudeEnvironment();
+			expect(claude.getFragmentDirs()).toEqual(["shared/", "claude/orchestration/"]);
+		});
+
+		it("ClaudeEnvironment.getIndexFile() returns 'CLAUDE.md'", () => {
+			const claude = new ClaudeEnvironment();
+			expect(claude.getIndexFile()).toBe("CLAUDE.md");
 		});
 	});
 

--- a/tests/core/fragmenter.test.ts
+++ b/tests/core/fragmenter.test.ts
@@ -1,0 +1,363 @@
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	generateIndex,
+	hasConflictMarkers,
+	parseIndex,
+	resolveFragmentPath,
+	splitMarkdownIntoFragments,
+} from "../../src/core/fragmenter.js";
+
+describe("fragmenter", () => {
+	describe("splitMarkdownIntoFragments", () => {
+		it("splits content into fragments by ## headers", () => {
+			const content = [
+				"# Global Config",
+				"",
+				"Some preamble text.",
+				"",
+				"## TDD & Testing",
+				"TDD is non-negotiable.",
+				"",
+				"## Code Quality",
+				"Small functions, single responsibility.",
+			].join("\n");
+
+			const sectionMap = new Map([
+				["## TDD & Testing", "shared/standards/tdd.md"],
+				["## Code Quality", "shared/standards/code-quality.md"],
+			]);
+
+			const result = splitMarkdownIntoFragments(content, sectionMap);
+
+			expect(result.fragments).toHaveLength(2);
+			expect(result.fragments[0]?.path).toBe("shared/standards/tdd.md");
+			expect(result.fragments[1]?.path).toBe("shared/standards/code-quality.md");
+		});
+
+		it("includes the ## header line at the start of each fragment", () => {
+			const content = ["## Stack", "TypeScript strict mode."].join("\n");
+
+			const sectionMap = new Map([["## Stack", "shared/standards/stack.md"]]);
+			const result = splitMarkdownIntoFragments(content, sectionMap);
+
+			expect(result.fragments[0]?.content).toContain("## Stack");
+			expect(result.fragments[0]?.content).toContain("TypeScript strict mode.");
+		});
+
+		it("keeps nested ### headers within the parent fragment", () => {
+			const content = [
+				"## Architecture",
+				"",
+				"### Interfaces",
+				"Depend on abstractions.",
+				"",
+				"### Separation",
+				"Keep layers clean.",
+				"",
+				"## Testing",
+				"Write tests first.",
+			].join("\n");
+
+			const sectionMap = new Map([
+				["## Architecture", "shared/arch.md"],
+				["## Testing", "shared/testing.md"],
+			]);
+
+			const result = splitMarkdownIntoFragments(content, sectionMap);
+
+			expect(result.fragments).toHaveLength(2);
+			const archContent = result.fragments[0]?.content ?? "";
+			expect(archContent).toContain("### Interfaces");
+			expect(archContent).toContain("### Separation");
+			expect(archContent).toContain("Depend on abstractions.");
+			// Testing section should NOT be in architecture fragment
+			expect(archContent).not.toContain("Write tests first.");
+		});
+
+		it("preserves preamble content before the first ## header", () => {
+			const content = [
+				"# My Config",
+				"",
+				"This is a preamble line.",
+				"",
+				"## Standards",
+				"Quality matters.",
+			].join("\n");
+
+			const sectionMap = new Map([["## Standards", "shared/standards.md"]]);
+			const result = splitMarkdownIntoFragments(content, sectionMap);
+
+			expect(result.indexContent).toContain("# My Config");
+			expect(result.indexContent).toContain("This is a preamble line.");
+		});
+
+		it("skips sections with no mapped path in sectionMap", () => {
+			const content = ["## Known", "content", "", "## Unknown", "also content"].join("\n");
+
+			const sectionMap = new Map([["## Known", "shared/known.md"]]);
+			const result = splitMarkdownIntoFragments(content, sectionMap);
+
+			expect(result.fragments).toHaveLength(1);
+			expect(result.fragments[0]?.path).toBe("shared/known.md");
+		});
+
+		it("skips empty sections", () => {
+			const content = ["## EmptySection", "", "", "## RealSection", "Has content."].join("\n");
+
+			const sectionMap = new Map([
+				["## EmptySection", "shared/empty.md"],
+				["## RealSection", "shared/real.md"],
+			]);
+
+			const result = splitMarkdownIntoFragments(content, sectionMap);
+
+			// EmptySection only has "## EmptySection" header — after trimEnd that's non-empty
+			// but let's check the actual behavior: header alone is NOT empty
+			const emptyFrag = result.fragments.find((f) => f.path === "shared/empty.md");
+			const realFrag = result.fragments.find((f) => f.path === "shared/real.md");
+			expect(realFrag).toBeDefined();
+			expect(realFrag?.content).toContain("Has content.");
+			// EmptySection has a header line, so it won't be completely empty
+			if (emptyFrag) {
+				expect(emptyFrag.content.trim()).toBe("## EmptySection");
+			}
+		});
+
+		it("treats content before any ## header as preamble (no fragment)", () => {
+			const content = [
+				"# Top level heading",
+				"Some intro.",
+				"More intro.",
+				"",
+				"## Section",
+				"Body.",
+			].join("\n");
+
+			const sectionMap = new Map([["## Section", "shared/section.md"]]);
+			const result = splitMarkdownIntoFragments(content, sectionMap);
+
+			// Only one fragment — preamble not a fragment
+			expect(result.fragments).toHaveLength(1);
+			expect(result.indexContent).toContain("# Top level heading");
+		});
+
+		it("handles content with no ## headers — everything is preamble", () => {
+			const content = "# Title\n\nJust a preamble. No sections here.";
+			const sectionMap = new Map<string, string>();
+
+			const result = splitMarkdownIntoFragments(content, sectionMap);
+
+			expect(result.fragments).toHaveLength(0);
+			expect(result.indexContent).toContain("# Title");
+			expect(result.indexContent).toContain("Just a preamble.");
+		});
+
+		it("handles a single section with no preamble", () => {
+			const content = ["## Only Section", "Content here."].join("\n");
+			const sectionMap = new Map([["## Only Section", "shared/only.md"]]);
+
+			const result = splitMarkdownIntoFragments(content, sectionMap);
+
+			expect(result.fragments).toHaveLength(1);
+			expect(result.fragments[0]?.path).toBe("shared/only.md");
+		});
+
+		it("produces references in the index in document order", () => {
+			const content = [
+				"## First",
+				"aaa",
+				"",
+				"## Second",
+				"bbb",
+				"",
+				"## Third",
+				"ccc",
+			].join("\n");
+
+			const sectionMap = new Map([
+				["## First", "shared/first.md"],
+				["## Second", "shared/second.md"],
+				["## Third", "shared/third.md"],
+			]);
+
+			const result = splitMarkdownIntoFragments(content, sectionMap);
+			const parsed = parseIndex(result.indexContent);
+
+			expect(parsed.references).toEqual([
+				"shared/first.md",
+				"shared/second.md",
+				"shared/third.md",
+			]);
+		});
+
+		it("infers scope from the first path segment", () => {
+			const content = ["## TDD", "test first"].join("\n");
+			const sectionMap = new Map([["## TDD", "myenv/tdd.md"]]);
+
+			const result = splitMarkdownIntoFragments(content, sectionMap);
+			expect(result.fragments[0]?.scope).toBe("myenv");
+		});
+
+		it("uses 'shared' as scope for shared/ paths", () => {
+			const content = ["## TDD", "test first"].join("\n");
+			const sectionMap = new Map([["## TDD", "shared/tdd.md"]]);
+
+			const result = splitMarkdownIntoFragments(content, sectionMap);
+			expect(result.fragments[0]?.scope).toBe("shared");
+		});
+
+		it("handles trailing newlines in content gracefully", () => {
+			const content = "## Section\nBody.\n\n\n";
+			const sectionMap = new Map([["## Section", "shared/section.md"]]);
+
+			const result = splitMarkdownIntoFragments(content, sectionMap);
+			expect(result.fragments).toHaveLength(1);
+			// Content should not have excessive trailing whitespace
+			expect(result.fragments[0]?.content).toBe("## Section\nBody.");
+		});
+	});
+
+	describe("generateIndex", () => {
+		it("produces preamble followed by @-references", () => {
+			const result = generateIndex("# Config", ["shared/tdd.md", "shared/quality.md"]);
+			expect(result).toBe("# Config\n\n@shared/tdd.md\n@shared/quality.md");
+		});
+
+		it("returns only references when preamble is empty", () => {
+			const result = generateIndex("", ["shared/tdd.md"]);
+			expect(result).toBe("@shared/tdd.md");
+		});
+
+		it("returns only preamble when references is empty", () => {
+			const result = generateIndex("# Just Preamble", []);
+			expect(result).toBe("# Just Preamble");
+		});
+
+		it("each reference is on its own line prefixed with @", () => {
+			const result = generateIndex("", ["a/b.md", "c/d.md", "e/f.md"]);
+			const lines = result.split("\n");
+			expect(lines).toEqual(["@a/b.md", "@c/d.md", "@e/f.md"]);
+		});
+	});
+
+	describe("parseIndex", () => {
+		it("extracts preamble and reference paths", () => {
+			const content = "# Config\n\nSome text.\n\n@shared/tdd.md\n@shared/quality.md";
+			const result = parseIndex(content);
+
+			expect(result.preamble).toBe("# Config\n\nSome text.");
+			expect(result.references).toEqual(["shared/tdd.md", "shared/quality.md"]);
+		});
+
+		it("handles content with only references (no preamble)", () => {
+			const content = "@shared/a.md\n@shared/b.md";
+			const result = parseIndex(content);
+
+			expect(result.preamble).toBe("");
+			expect(result.references).toEqual(["shared/a.md", "shared/b.md"]);
+		});
+
+		it("handles content with only preamble (no references)", () => {
+			const content = "# Title\n\nJust text.";
+			const result = parseIndex(content);
+
+			expect(result.preamble).toBe("# Title\n\nJust text.");
+			expect(result.references).toEqual([]);
+		});
+
+		it("strips the leading @ from reference paths", () => {
+			const content = "@some/path/fragment.md";
+			const result = parseIndex(content);
+			expect(result.references[0]).toBe("some/path/fragment.md");
+		});
+
+		it("handles trimmed @ lines (leading whitespace)", () => {
+			const content = "preamble\n  @shared/a.md";
+			const result = parseIndex(content);
+			expect(result.references).toEqual(["shared/a.md"]);
+		});
+	});
+
+	describe("parseIndex / generateIndex roundtrip", () => {
+		it("roundtrips preamble and references correctly", () => {
+			const preamble = "# My Config\n\nSome description.";
+			const references = ["shared/tdd.md", "shared/stack.md", "shared/arch.md"];
+
+			const indexContent = generateIndex(preamble, references);
+			const parsed = parseIndex(indexContent);
+
+			expect(parsed.preamble).toBe(preamble);
+			expect(parsed.references).toEqual(references);
+		});
+
+		it("roundtrips with empty preamble", () => {
+			const references = ["shared/a.md", "shared/b.md"];
+			const indexContent = generateIndex("", references);
+			const parsed = parseIndex(indexContent);
+
+			expect(parsed.preamble).toBe("");
+			expect(parsed.references).toEqual(references);
+		});
+
+		it("roundtrips with empty references", () => {
+			const preamble = "# Just a title";
+			const indexContent = generateIndex(preamble, []);
+			const parsed = parseIndex(indexContent);
+
+			expect(parsed.preamble).toBe(preamble);
+			expect(parsed.references).toEqual([]);
+		});
+	});
+
+	describe("resolveFragmentPath", () => {
+		it("joins sync repo dir with the reference path after stripping @", () => {
+			const syncRepoDir = "/home/user/.ai-sync";
+			const result = resolveFragmentPath("@shared/standards/tdd.md", syncRepoDir);
+			expect(result).toBe(path.join("/home/user/.ai-sync", "shared/standards/tdd.md"));
+		});
+
+		it("works when reference has no leading @", () => {
+			const syncRepoDir = "/home/user/.ai-sync";
+			const result = resolveFragmentPath("shared/standards/tdd.md", syncRepoDir);
+			expect(result).toBe(path.join("/home/user/.ai-sync", "shared/standards/tdd.md"));
+		});
+
+		it("returns an absolute path", () => {
+			const result = resolveFragmentPath("@shared/x.md", "/sync");
+			expect(path.isAbsolute(result)).toBe(true);
+		});
+
+		it("handles nested paths", () => {
+			const syncRepoDir = "/repo";
+			const result = resolveFragmentPath("@env/work/deep/fragment.md", syncRepoDir);
+			expect(result).toBe(path.join("/repo", "env/work/deep/fragment.md"));
+		});
+	});
+
+	describe("hasConflictMarkers", () => {
+		it("returns true when content contains <<<<<<<", () => {
+			const content = "some text\n<<<<<<< HEAD\nmy version\n=======\nother\n>>>>>>> branch";
+			expect(hasConflictMarkers(content)).toBe(true);
+		});
+
+		it("returns true when content contains >>>>>>>", () => {
+			const content = ">>>>>>> branch-name";
+			expect(hasConflictMarkers(content)).toBe(true);
+		});
+
+		it("returns false for clean content", () => {
+			const content = "# Clean file\n\nNo conflict markers here.";
+			expect(hasConflictMarkers(content)).toBe(false);
+		});
+
+		it("returns false for empty string", () => {
+			expect(hasConflictMarkers("")).toBe(false);
+		});
+
+		it("detects conflict markers embedded in larger text", () => {
+			const content = "line1\nline2\n<<<<<<< HEAD\nconflict\n=======\nother\n>>>>>>>\nline3";
+			expect(hasConflictMarkers(content)).toBe(true);
+		});
+	});
+});

--- a/tests/core/linker.test.ts
+++ b/tests/core/linker.test.ts
@@ -7,6 +7,7 @@ import {
 	getLinkableTargets,
 	getUnlinkableTargets,
 	linkEnvironment,
+	linkSharedDirectory,
 	unlinkEnvironment,
 } from "../../src/core/linker.js";
 
@@ -200,6 +201,75 @@ describe("core/linker", () => {
 			expect(result.linked).toContain("CLAUDE.md");
 			const content = fs.readFileSync(path.join(configDir, "CLAUDE.md"), "utf-8");
 			expect(content).toBe("# From repo");
+		});
+	});
+
+	describe("linkSharedDirectory", () => {
+		it("creates symlink when shared/ exists in repo", async () => {
+			// Create shared/ in the repo
+			const repoSharedDir = path.join(syncRepoDir, "shared");
+			fs.mkdirSync(repoSharedDir, { recursive: true });
+			fs.writeFileSync(path.join(repoSharedDir, "standards.md"), "# Standards");
+
+			const result = await linkSharedDirectory(syncRepoDir, configDir, backupDir);
+
+			expect(result.linked).toBe(true);
+			expect(result.backedUp).toBe(false);
+			// configDir/shared should be a symlink pointing to repoSharedDir
+			const stat = fs.lstatSync(path.join(configDir, "shared"));
+			expect(stat.isSymbolicLink()).toBe(true);
+			const target = fs.readlinkSync(path.join(configDir, "shared"));
+			expect(target).toBe(repoSharedDir);
+		});
+
+		it("returns linked:false when shared/ does not exist in repo", async () => {
+			const result = await linkSharedDirectory(syncRepoDir, configDir, backupDir);
+
+			expect(result.linked).toBe(false);
+			expect(result.backedUp).toBe(false);
+		});
+
+		it("backs up existing real directory before linking", async () => {
+			// Create shared/ in the repo
+			const repoSharedDir = path.join(syncRepoDir, "shared");
+			fs.mkdirSync(repoSharedDir, { recursive: true });
+			fs.writeFileSync(path.join(repoSharedDir, "standards.md"), "# Repo standards");
+
+			// Create a real shared/ in the config dir
+			const configSharedDir = path.join(configDir, "shared");
+			fs.mkdirSync(configSharedDir, { recursive: true });
+			fs.writeFileSync(path.join(configSharedDir, "local.md"), "# Local content");
+
+			const result = await linkSharedDirectory(syncRepoDir, configDir, backupDir);
+
+			expect(result.linked).toBe(true);
+			expect(result.backedUp).toBe(true);
+			// Backup should contain the original file
+			const backedUpContent = fs.readFileSync(path.join(backupDir, "shared", "local.md"), "utf-8");
+			expect(backedUpContent).toBe("# Local content");
+			// configDir/shared should now be a symlink
+			const stat = fs.lstatSync(path.join(configDir, "shared"));
+			expect(stat.isSymbolicLink()).toBe(true);
+		});
+
+		it("replaces existing symlink without backup", async () => {
+			// Create shared/ in the repo
+			const repoSharedDir = path.join(syncRepoDir, "shared");
+			fs.mkdirSync(repoSharedDir, { recursive: true });
+			fs.writeFileSync(path.join(repoSharedDir, "standards.md"), "# Standards");
+
+			// Create an old symlink pointing elsewhere
+			const otherDir = path.join(tmpDir, "other");
+			fs.mkdirSync(otherDir, { recursive: true });
+			fs.symlinkSync(otherDir, path.join(configDir, "shared"));
+
+			const result = await linkSharedDirectory(syncRepoDir, configDir, backupDir);
+
+			expect(result.linked).toBe(true);
+			expect(result.backedUp).toBe(false);
+			// Should now point to the repo shared dir
+			const target = fs.readlinkSync(path.join(configDir, "shared"));
+			expect(target).toBe(repoSharedDir);
 		});
 	});
 

--- a/tests/core/manifest.test.ts
+++ b/tests/core/manifest.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
 	DEFAULT_SYNC_TARGETS,
 	isPathAllowed,
+	isRepoLevelPathAllowed,
 	PLUGIN_IGNORE_PATTERNS,
 	PLUGIN_SYNC_PATTERNS,
+	REPO_LEVEL_SYNC_TARGETS,
 } from "../../src/core/manifest.js";
 
 describe("manifest", () => {
@@ -125,6 +127,31 @@ describe("manifest", () => {
 
 		it("rejects unknown directories", () => {
 			expect(isPathAllowed("unknown-new-directory/file.txt")).toBe(false);
+		});
+	});
+
+	describe("REPO_LEVEL_SYNC_TARGETS", () => {
+		it("contains shared/ and tools/", () => {
+			expect(REPO_LEVEL_SYNC_TARGETS).toContain("shared/");
+			expect(REPO_LEVEL_SYNC_TARGETS).toContain("tools/");
+		});
+	});
+
+	describe("isRepoLevelPathAllowed", () => {
+		it("allows files nested under shared/", () => {
+			expect(isRepoLevelPathAllowed("shared/standards/tdd.md")).toBe(true);
+		});
+
+		it("allows files nested under tools/", () => {
+			expect(isRepoLevelPathAllowed("tools/manifest.json")).toBe(true);
+		});
+
+		it("rejects paths not in repo-level targets", () => {
+			expect(isRepoLevelPathAllowed("random/file.txt")).toBe(false);
+		});
+
+		it("rejects paths that are prefix matches but not under a target dir", () => {
+			expect(isRepoLevelPathAllowed("shared-other/file.txt")).toBe(false);
 		});
 	});
 });

--- a/tests/core/migration.test.ts
+++ b/tests/core/migration.test.ts
@@ -3,7 +3,12 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { simpleGit } from "simple-git";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { detectRepoVersion, migrateToV2 } from "../../src/core/migration.js";
+import {
+	checkVersionCompatibility,
+	detectRepoVersion,
+	migrateToV2,
+	migrateToV3,
+} from "../../src/core/migration.js";
 import {
 	addFiles,
 	addRemote,
@@ -51,10 +56,16 @@ describe("migration", () => {
 		await fs.mkdir(path.join(syncRepoDir, "agents"), { recursive: true });
 		await fs.writeFile(path.join(syncRepoDir, "agents", "default.md"), "agent");
 
-		await addFiles(syncRepoDir, ["."]);
+		await addFiles(syncRepoDir, ["CLAUDE.md", "settings.json", "agents/default.md"]);
 		await commitFiles(syncRepoDir, "feat: initial sync");
 		await simpleGit(syncRepoDir).push("origin", "main");
 
+		return syncRepoDir;
+	}
+
+	async function createV2Repo(): Promise<string> {
+		const syncRepoDir = await createV1Repo();
+		await migrateToV2(syncRepoDir);
 		return syncRepoDir;
 	}
 
@@ -70,6 +81,13 @@ describe("migration", () => {
 			await fs.writeFile(path.join(repoDir, ".sync-version"), "2\n");
 			const version = await detectRepoVersion(repoDir);
 			expect(version).toBe(2);
+		});
+
+		it("returns 3 for repos with .sync-version containing '3'", async () => {
+			const repoDir = await createV1Repo();
+			await fs.writeFile(path.join(repoDir, ".sync-version"), "3\n");
+			const version = await detectRepoVersion(repoDir);
+			expect(version).toBe(3);
 		});
 
 		it("returns 1 for repos with .sync-version containing other content", async () => {
@@ -148,6 +166,87 @@ describe("migration", () => {
 
 			const version = await detectRepoVersion(repoDir);
 			expect(version).toBe(2);
+		});
+	});
+
+	describe("migrateToV3", () => {
+		it("creates shared/ directory", async () => {
+			const repoDir = await createV2Repo();
+			await migrateToV3(repoDir);
+
+			await expect(
+				fs.access(path.join(repoDir, "shared"), fs.constants.F_OK),
+			).resolves.toBeUndefined();
+		});
+
+		it("creates tools/ directory", async () => {
+			const repoDir = await createV2Repo();
+			await migrateToV3(repoDir);
+
+			await expect(
+				fs.access(path.join(repoDir, "tools"), fs.constants.F_OK),
+			).resolves.toBeUndefined();
+		});
+
+		it("writes '3\\n' to .sync-version", async () => {
+			const repoDir = await createV2Repo();
+			await migrateToV3(repoDir);
+
+			const content = await fs.readFile(path.join(repoDir, ".sync-version"), "utf-8");
+			expect(content).toBe("3\n");
+		});
+
+		it("creates a commit with migration message", async () => {
+			const repoDir = await createV2Repo();
+			await migrateToV3(repoDir);
+
+			const git = simpleGit(repoDir);
+			const log = await git.log();
+			expect(log.latest?.message).toBe("chore: migrate sync repo to v3 format");
+		});
+
+		it("throws when repo is at v1", async () => {
+			const repoDir = await createV1Repo();
+			await expect(migrateToV3(repoDir)).rejects.toThrow(/migrate to v2 first/i);
+		});
+
+		it("returns already-at-v3 result for v3 repos", async () => {
+			const repoDir = await createV2Repo();
+			await migrateToV3(repoDir);
+
+			const result = await migrateToV3(repoDir);
+			expect(result.success).toBe(true);
+			expect(result.message).toContain("Already at v3");
+		});
+
+		it("detectRepoVersion returns 3 after migration", async () => {
+			const repoDir = await createV2Repo();
+			await migrateToV3(repoDir);
+
+			const version = await detectRepoVersion(repoDir);
+			expect(version).toBe(3);
+		});
+	});
+
+	describe("checkVersionCompatibility", () => {
+		it("does not throw for version 1", () => {
+			expect(() => checkVersionCompatibility(1)).not.toThrow();
+		});
+
+		it("does not throw for version 2", () => {
+			expect(() => checkVersionCompatibility(2)).not.toThrow();
+		});
+
+		it("does not throw for version 3", () => {
+			expect(() => checkVersionCompatibility(3)).not.toThrow();
+		});
+
+		it("throws for version greater than 3", () => {
+			expect(() => checkVersionCompatibility(4)).toThrow(/Unknown repo version 4/);
+		});
+
+		it("throws with update message for unknown version", () => {
+			expect(() => checkVersionCompatibility(99)).toThrow(/Please update ai-sync/);
 		});
 	});
 });

--- a/tests/core/provisioner.test.ts
+++ b/tests/core/provisioner.test.ts
@@ -1,0 +1,704 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	discoverPipTools,
+	discoverPlugins,
+	formatInstallSummary,
+	generateInstallScript,
+	installTool,
+	preflightCheck,
+	provision,
+	verifyTool,
+	writeManifest,
+} from "../../src/core/provisioner.js";
+import type { ToolEntry, ToolManifest } from "../../src/core/tool-manifest.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeExecFn(
+	responses: Record<string, { stdout?: string; stderr?: string; throws?: boolean }>,
+) {
+	return vi.fn(async (cmd: string, args: string[]) => {
+		const key = [cmd, ...args].join(" ");
+		// Try exact match first, then prefix match
+		const entry = responses[key] ?? Object.entries(responses).find(([k]) => key.startsWith(k))?.[1];
+		if (!entry) {
+			throw new Error(`Unexpected exec call: ${key}`);
+		}
+		if (entry.throws) throw new Error(`exec failed: ${key}`);
+		return { stdout: entry.stdout ?? "", stderr: entry.stderr ?? "" };
+	});
+}
+
+function makeToolEntry(overrides: Partial<ToolEntry> = {}): ToolEntry {
+	return {
+		name: "mytool",
+		type: "pip",
+		package: "mytool",
+		postInstall: { type: "none" },
+		verify: { type: "pip-package", name: "mytool" },
+		required: true,
+		...overrides,
+	};
+}
+
+function makeManifest(tools: ToolEntry[], autoInstall = false): ToolManifest {
+	return {
+		version: 1,
+		discoveredAt: "2025-01-01T00:00:00.000Z",
+		sourcePlatform: "darwin",
+		tools,
+		autoInstall,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// preflightCheck
+// ---------------------------------------------------------------------------
+
+describe("preflightCheck", () => {
+	it("returns ok:true when all required managers are available", async () => {
+		const execFn = makeExecFn({
+			"which pip": { stdout: "/usr/bin/pip" },
+			"which npm": { stdout: "/usr/bin/npm" },
+		});
+
+		const manifest = makeManifest([
+			makeToolEntry({ type: "pip", verify: { type: "pip-package", name: "requests" } }),
+			makeToolEntry({
+				name: "typescript",
+				type: "npm",
+				verify: { type: "npm-package", name: "typescript" },
+			}),
+		]);
+
+		const result = await preflightCheck(manifest, execFn);
+		expect(result.ok).toBe(true);
+		expect(result.missing).toEqual([]);
+	});
+
+	it("returns ok:false with missing list when a manager is not found", async () => {
+		const execFn = makeExecFn({
+			"which pip": { throws: true },
+			"which cargo": { throws: true },
+		});
+
+		const manifest = makeManifest([
+			makeToolEntry({ type: "pip", verify: { type: "pip-package", name: "requests" } }),
+			makeToolEntry({
+				name: "rg",
+				type: "cargo",
+				package: "ripgrep",
+				verify: { type: "cargo-crate", name: "ripgrep" },
+			}),
+		]);
+
+		const result = await preflightCheck(manifest, execFn);
+		expect(result.ok).toBe(false);
+		expect(result.missing).toContain("pip");
+		expect(result.missing).toContain("cargo");
+	});
+
+	it("returns ok:true for manifest with only system tools (no managers needed)", async () => {
+		const execFn = makeExecFn({});
+
+		const manifest = makeManifest([
+			makeToolEntry({
+				name: "git",
+				type: "system",
+				verify: { type: "binary-exists", name: "git" },
+			}),
+		]);
+
+		const result = await preflightCheck(manifest, execFn);
+		expect(result.ok).toBe(true);
+		expect(result.missing).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// formatInstallSummary
+// ---------------------------------------------------------------------------
+
+describe("formatInstallSummary", () => {
+	it("produces readable output with exact commands for pip tools", () => {
+		const tools: ToolEntry[] = [
+			makeToolEntry({
+				name: "requests",
+				type: "pip",
+				package: "requests",
+				verify: { type: "pip-package", name: "requests" },
+			}),
+		];
+		const summary = formatInstallSummary(tools);
+		expect(summary).toContain("requests");
+		expect(summary).toContain("pip install requests");
+	});
+
+	it("produces readable output for cargo tools", () => {
+		const tools: ToolEntry[] = [
+			makeToolEntry({
+				name: "rg",
+				type: "cargo",
+				package: "ripgrep",
+				verify: { type: "cargo-crate", name: "ripgrep" },
+			}),
+		];
+		const summary = formatInstallSummary(tools);
+		expect(summary).toContain("cargo install ripgrep");
+	});
+
+	it("produces readable output for npm tools", () => {
+		const tools: ToolEntry[] = [
+			makeToolEntry({
+				name: "ts",
+				type: "npm",
+				package: "typescript",
+				verify: { type: "npm-package", name: "typescript" },
+			}),
+		];
+		const summary = formatInstallSummary(tools);
+		expect(summary).toContain("npm install -g typescript");
+	});
+
+	it("shows plugin instruction for claude-plugin tools", () => {
+		const tools: ToolEntry[] = [
+			makeToolEntry({
+				name: "my-plugin",
+				type: "claude-plugin",
+				marketplace: "https://example.com",
+				verify: { type: "binary-exists", name: "my-plugin" },
+			}),
+		];
+		const summary = formatInstallSummary(tools);
+		expect(summary).toContain("my-plugin");
+		expect(summary).toContain("marketplace");
+	});
+
+	it("returns 'No tools to install.' for empty list", () => {
+		expect(formatInstallSummary([])).toBe("No tools to install.");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// installTool
+// ---------------------------------------------------------------------------
+
+describe("installTool", () => {
+	it("calls pip install for pip tools", async () => {
+		const execFn = makeExecFn({ "pip install requests": { stdout: "" } });
+		const tool = makeToolEntry({
+			name: "requests",
+			type: "pip",
+			package: "requests",
+			verify: { type: "pip-package", name: "requests" },
+		});
+		await installTool(tool, execFn);
+		expect(execFn).toHaveBeenCalledWith("pip", ["install", "requests"]);
+	});
+
+	it("calls cargo install for cargo tools", async () => {
+		const execFn = makeExecFn({ "cargo install ripgrep": { stdout: "" } });
+		const tool = makeToolEntry({
+			name: "rg",
+			type: "cargo",
+			package: "ripgrep",
+			verify: { type: "cargo-crate", name: "ripgrep" },
+		});
+		await installTool(tool, execFn);
+		expect(execFn).toHaveBeenCalledWith("cargo", ["install", "ripgrep"]);
+	});
+
+	it("calls npm install -g for npm tools", async () => {
+		const execFn = makeExecFn({ "npm install -g typescript": { stdout: "" } });
+		const tool = makeToolEntry({
+			name: "typescript",
+			type: "npm",
+			package: "typescript",
+			verify: { type: "npm-package", name: "typescript" },
+		});
+		await installTool(tool, execFn);
+		expect(execFn).toHaveBeenCalledWith("npm", ["install", "-g", "typescript"]);
+	});
+
+	it("does not call execFn for claude-plugin tools", async () => {
+		const execFn = vi.fn();
+		const tool = makeToolEntry({
+			name: "my-plugin",
+			type: "claude-plugin",
+			verify: { type: "binary-exists", name: "my-plugin" },
+		});
+		await installTool(tool, execFn);
+		expect(execFn).not.toHaveBeenCalled();
+	});
+
+	it("does not call execFn for system tools", async () => {
+		const execFn = vi.fn();
+		const tool = makeToolEntry({
+			name: "git",
+			type: "system",
+			verify: { type: "binary-exists", name: "git" },
+		});
+		await installTool(tool, execFn);
+		expect(execFn).not.toHaveBeenCalled();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// verifyTool
+// ---------------------------------------------------------------------------
+
+describe("verifyTool", () => {
+	it("dispatches binary-exists via which", async () => {
+		const execFn = makeExecFn({ "which git": { stdout: "/usr/bin/git" } });
+		const tool = makeToolEntry({
+			name: "git",
+			type: "system",
+			verify: { type: "binary-exists", name: "git" },
+		});
+		const ok = await verifyTool(tool, execFn);
+		expect(ok).toBe(true);
+		expect(execFn).toHaveBeenCalledWith("which", ["git"]);
+	});
+
+	it("returns false for binary-exists when which fails", async () => {
+		const execFn = makeExecFn({ "which notfound": { throws: true } });
+		const tool = makeToolEntry({
+			name: "notfound",
+			type: "system",
+			verify: { type: "binary-exists", name: "notfound" },
+		});
+		const ok = await verifyTool(tool, execFn);
+		expect(ok).toBe(false);
+	});
+
+	it("dispatches command-output and checks expectContains", async () => {
+		const execFn = makeExecFn({ "node --version": { stdout: "v22.0.0" } });
+		const tool = makeToolEntry({
+			name: "node",
+			type: "system",
+			verify: {
+				type: "command-output",
+				command: "node",
+				args: ["--version"],
+				expectContains: "v22",
+			},
+		});
+		const ok = await verifyTool(tool, execFn);
+		expect(ok).toBe(true);
+	});
+
+	it("returns false for command-output when expectContains not found", async () => {
+		const execFn = makeExecFn({ "node --version": { stdout: "v20.0.0" } });
+		const tool = makeToolEntry({
+			name: "node",
+			type: "system",
+			verify: {
+				type: "command-output",
+				command: "node",
+				args: ["--version"],
+				expectContains: "v22",
+			},
+		});
+		const ok = await verifyTool(tool, execFn);
+		expect(ok).toBe(false);
+	});
+
+	it("dispatches pip-package via pip show", async () => {
+		const execFn = makeExecFn({
+			"pip show requests": { stdout: "Name: requests\nVersion: 2.31.0\n" },
+		});
+		const tool = makeToolEntry({
+			name: "requests",
+			type: "pip",
+			package: "requests",
+			verify: { type: "pip-package", name: "requests" },
+		});
+		const ok = await verifyTool(tool, execFn);
+		expect(ok).toBe(true);
+		expect(execFn).toHaveBeenCalledWith("pip", ["show", "requests"]);
+	});
+
+	it("dispatches npm-package via npm list -g", async () => {
+		const execFn = makeExecFn({
+			"npm list -g typescript": { stdout: "/usr/local/lib\n└── typescript@5.0.0\n" },
+		});
+		const tool = makeToolEntry({
+			name: "typescript",
+			type: "npm",
+			package: "typescript",
+			verify: { type: "npm-package", name: "typescript" },
+		});
+		const ok = await verifyTool(tool, execFn);
+		expect(ok).toBe(true);
+		expect(execFn).toHaveBeenCalledWith("npm", ["list", "-g", "typescript"]);
+	});
+
+	it("returns false when verify command throws", async () => {
+		const execFn = makeExecFn({ "pip show missing": { throws: true } });
+		const tool = makeToolEntry({
+			name: "missing",
+			type: "pip",
+			package: "missing",
+			verify: { type: "pip-package", name: "missing" },
+		});
+		const ok = await verifyTool(tool, execFn);
+		expect(ok).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// provision — autoInstall: false
+// ---------------------------------------------------------------------------
+
+describe("provision with autoInstall:false", () => {
+	it("returns commands without executing any installs", async () => {
+		const execFn = vi.fn();
+		const manifest = makeManifest([
+			makeToolEntry({
+				name: "requests",
+				type: "pip",
+				package: "requests",
+				verify: { type: "pip-package", name: "requests" },
+			}),
+		]);
+
+		const result = await provision({
+			manifest,
+			autoInstall: false,
+			execFn,
+			backupDir: "/tmp/backup",
+		});
+
+		expect(result.commands).toContain("pip install requests");
+		expect(result.installed).toHaveLength(0);
+		expect(result.skipped).toHaveLength(1);
+		expect(execFn).not.toHaveBeenCalled();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// provision — autoInstall: true, confirm, install, verify
+// ---------------------------------------------------------------------------
+
+describe("provision with autoInstall:true", () => {
+	it("calls confirmFn, installs, and verifies", async () => {
+		const execFn = makeExecFn({
+			"which pip": { stdout: "/usr/bin/pip" },
+			"pip install requests": { stdout: "" },
+			"pip show requests": { stdout: "Name: requests\nVersion: 2.31.0\n" },
+		});
+		const confirmFn = vi.fn(async () => true);
+		const manifest = makeManifest([
+			makeToolEntry({
+				name: "requests",
+				type: "pip",
+				package: "requests",
+				verify: { type: "pip-package", name: "requests" },
+			}),
+		]);
+
+		const result = await provision({
+			manifest,
+			autoInstall: true,
+			confirmFn,
+			execFn,
+			backupDir: "/tmp/backup",
+		});
+
+		expect(confirmFn).toHaveBeenCalledOnce();
+		expect(result.installed).toHaveLength(1);
+		expect(result.failed).toHaveLength(0);
+		expect(result.rolledBack).toBe(false);
+	});
+
+	it("skips all tools when confirmFn returns false", async () => {
+		const execFn = vi.fn();
+		const confirmFn = vi.fn(async () => false);
+		const manifest = makeManifest([
+			makeToolEntry({
+				name: "requests",
+				type: "pip",
+				package: "requests",
+				verify: { type: "pip-package", name: "requests" },
+			}),
+		]);
+
+		const result = await provision({
+			manifest,
+			autoInstall: true,
+			confirmFn,
+			execFn,
+			backupDir: "/tmp/backup",
+		});
+
+		expect(result.skipped).toHaveLength(1);
+		expect(result.installed).toHaveLength(0);
+		expect(execFn).not.toHaveBeenCalled();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// provision — rollback on failure
+// ---------------------------------------------------------------------------
+
+describe("provision rollback", () => {
+	it("uninstalls previously installed tools when a later install fails", async () => {
+		// tool-a installs successfully, tool-b fails
+		const execFn = makeExecFn({
+			"which pip": { stdout: "/usr/bin/pip" },
+			"pip install tool-a": { stdout: "" },
+			"pip show tool-a": { stdout: "Name: tool-a\nVersion: 1.0\n" },
+			"pip install tool-b": { throws: true },
+			"pip uninstall -y tool-a": { stdout: "" },
+		});
+		const confirmFn = vi.fn(async () => true);
+
+		const toolA = makeToolEntry({
+			name: "tool-a",
+			package: "tool-a",
+			verify: { type: "pip-package", name: "tool-a" },
+		});
+		const toolB = makeToolEntry({
+			name: "tool-b",
+			package: "tool-b",
+			verify: { type: "pip-package", name: "tool-b" },
+		});
+		const manifest = makeManifest([toolA, toolB]);
+
+		const result = await provision({
+			manifest,
+			autoInstall: true,
+			confirmFn,
+			execFn,
+			backupDir: "/tmp/backup",
+		});
+
+		expect(result.rolledBack).toBe(true);
+		expect(result.rollbackPartial).toBe(false);
+		expect(execFn).toHaveBeenCalledWith("pip", ["uninstall", "-y", "tool-a"]);
+	});
+
+	it("sets rollbackPartial when an uninstall during rollback fails", async () => {
+		const execFn = makeExecFn({
+			"which pip": { stdout: "/usr/bin/pip" },
+			"pip install tool-a": { stdout: "" },
+			"pip show tool-a": { stdout: "Name: tool-a\nVersion: 1.0\n" },
+			"pip install tool-b": { throws: true },
+			"pip uninstall -y tool-a": { throws: true },
+		});
+		const confirmFn = vi.fn(async () => true);
+
+		const toolA = makeToolEntry({
+			name: "tool-a",
+			package: "tool-a",
+			verify: { type: "pip-package", name: "tool-a" },
+		});
+		const toolB = makeToolEntry({
+			name: "tool-b",
+			package: "tool-b",
+			verify: { type: "pip-package", name: "tool-b" },
+		});
+		const manifest = makeManifest([toolA, toolB]);
+
+		const result = await provision({
+			manifest,
+			autoInstall: true,
+			confirmFn,
+			execFn,
+			backupDir: "/tmp/backup",
+		});
+
+		expect(result.rolledBack).toBe(true);
+		expect(result.rollbackPartial).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// generateInstallScript
+// ---------------------------------------------------------------------------
+
+describe("generateInstallScript", () => {
+	it("generates a valid shell script with install commands", () => {
+		const tools: ToolEntry[] = [
+			makeToolEntry({
+				name: "requests",
+				type: "pip",
+				package: "requests",
+				verify: { type: "pip-package", name: "requests" },
+			}),
+			makeToolEntry({
+				name: "rg",
+				type: "cargo",
+				package: "ripgrep",
+				verify: { type: "cargo-crate", name: "ripgrep" },
+			}),
+		];
+
+		const script = generateInstallScript(tools);
+		expect(script).toContain("#!/usr/bin/env bash");
+		expect(script).toContain("set -euo pipefail");
+		expect(script).toContain("pip install requests");
+		expect(script).toContain("cargo install ripgrep");
+	});
+
+	it("includes comments for system and claude-plugin tools", () => {
+		const tools: ToolEntry[] = [
+			makeToolEntry({
+				name: "my-plugin",
+				type: "claude-plugin",
+				verify: { type: "binary-exists", name: "my-plugin" },
+			}),
+			makeToolEntry({
+				name: "git",
+				type: "system",
+				verify: { type: "binary-exists", name: "git" },
+			}),
+		];
+
+		const script = generateInstallScript(tools);
+		expect(script).toContain("my-plugin");
+		expect(script).toContain("git");
+		// Should not contain actual install commands for these
+		expect(script).not.toContain("pip install my-plugin");
+		expect(script).not.toContain("apt install git");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// discoverPipTools
+// ---------------------------------------------------------------------------
+
+describe("discoverPipTools", () => {
+	it("parses pip show output and returns tool entries", async () => {
+		const execFn = makeExecFn({
+			"pip show requests": {
+				stdout: "Name: requests\nVersion: 2.31.0\nSummary: HTTP library\n",
+			},
+		});
+
+		const tools = await discoverPipTools(["requests"], execFn);
+		expect(tools).toHaveLength(1);
+		expect(tools[0].name).toBe("requests");
+		expect(tools[0].type).toBe("pip");
+		expect(tools[0].version).toBe("2.31.0");
+		expect(tools[0].verify).toEqual({ type: "pip-package", name: "requests" });
+	});
+
+	it("skips packages that are not installed (pip show throws)", async () => {
+		const execFn = makeExecFn({
+			"pip show missing-pkg": { throws: true },
+		});
+
+		const tools = await discoverPipTools(["missing-pkg"], execFn);
+		expect(tools).toHaveLength(0);
+	});
+
+	it("handles multiple packages", async () => {
+		const execFn = makeExecFn({
+			"pip show requests": { stdout: "Name: requests\nVersion: 2.31.0\n" },
+			"pip show flask": { stdout: "Name: flask\nVersion: 3.0.0\n" },
+		});
+
+		const tools = await discoverPipTools(["requests", "flask"], execFn);
+		expect(tools).toHaveLength(2);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// discoverPlugins
+// ---------------------------------------------------------------------------
+
+describe("discoverPlugins", () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "provisioner-test-"));
+	});
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("reads installed_plugins.json and returns plugin entries", async () => {
+		const plugins = [
+			{ name: "my-plugin", marketplace: "https://example.com" },
+			{ name: "another-plugin" },
+		];
+		await fs.writeFile(path.join(tmpDir, "installed_plugins.json"), JSON.stringify(plugins));
+
+		const entries = await discoverPlugins(tmpDir);
+		expect(entries).toHaveLength(2);
+		expect(entries[0].name).toBe("my-plugin");
+		expect(entries[0].type).toBe("claude-plugin");
+		expect(entries[0].marketplace).toBe("https://example.com");
+		expect(entries[1].name).toBe("another-plugin");
+	});
+
+	it("returns empty array when installed_plugins.json does not exist", async () => {
+		const entries = await discoverPlugins(tmpDir);
+		expect(entries).toHaveLength(0);
+	});
+
+	it("returns empty array when installed_plugins.json contains invalid JSON", async () => {
+		await fs.writeFile(path.join(tmpDir, "installed_plugins.json"), "not-json{{{");
+		const entries = await discoverPlugins(tmpDir);
+		expect(entries).toHaveLength(0);
+	});
+
+	it("returns empty array when installed_plugins.json is not an array", async () => {
+		await fs.writeFile(
+			path.join(tmpDir, "installed_plugins.json"),
+			JSON.stringify({ name: "plugin" }),
+		);
+		const entries = await discoverPlugins(tmpDir);
+		expect(entries).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// writeManifest
+// ---------------------------------------------------------------------------
+
+describe("writeManifest", () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "provisioner-manifest-test-"));
+	});
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("writes valid JSON to tools/manifest.json in the sync repo dir", async () => {
+		const manifest = makeManifest([
+			makeToolEntry({
+				name: "git",
+				type: "system",
+				verify: { type: "binary-exists", name: "git" },
+			}),
+		]);
+
+		await writeManifest(manifest, tmpDir);
+
+		const manifestPath = path.join(tmpDir, "tools", "manifest.json");
+		const raw = await fs.readFile(manifestPath, "utf-8");
+		const parsed = JSON.parse(raw) as ToolManifest;
+
+		expect(parsed.version).toBe(1);
+		expect(parsed.tools).toHaveLength(1);
+		expect(parsed.tools[0].name).toBe("git");
+	});
+
+	it("creates the tools/ directory if it does not exist", async () => {
+		const manifest = makeManifest([]);
+		await writeManifest(manifest, tmpDir);
+		const stat = await fs.stat(path.join(tmpDir, "tools"));
+		expect(stat.isDirectory()).toBe(true);
+	});
+});

--- a/tests/core/tool-manifest.test.ts
+++ b/tests/core/tool-manifest.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from "vitest";
+import {
+	PostInstallActionSchema,
+	ToolEntrySchema,
+	ToolManifestSchema,
+	ToolTypeSchema,
+	VerifyStrategySchema,
+} from "../../src/core/tool-manifest.js";
+
+const BASE_DATE = "2025-01-01T00:00:00.000Z";
+
+describe("tool-manifest", () => {
+	describe("ToolTypeSchema", () => {
+		it("accepts all valid tool types", () => {
+			for (const type of ["pip", "cargo", "npm", "claude-plugin", "system"]) {
+				expect(ToolTypeSchema.parse(type)).toBe(type);
+			}
+		});
+
+		it("rejects unknown tool types", () => {
+			expect(() => ToolTypeSchema.parse("brew")).toThrow();
+			expect(() => ToolTypeSchema.parse("")).toThrow();
+		});
+	});
+
+	describe("VerifyStrategySchema", () => {
+		it("accepts binary-exists strategy", () => {
+			const result = VerifyStrategySchema.parse({ type: "binary-exists", name: "git" });
+			expect(result).toEqual({ type: "binary-exists", name: "git" });
+		});
+
+		it("accepts command-output strategy", () => {
+			const result = VerifyStrategySchema.parse({
+				type: "command-output",
+				command: "node",
+				args: ["--version"],
+				expectContains: "v22",
+			});
+			expect(result).toEqual({
+				type: "command-output",
+				command: "node",
+				args: ["--version"],
+				expectContains: "v22",
+			});
+		});
+
+		it("accepts command-output without expectContains", () => {
+			const result = VerifyStrategySchema.parse({
+				type: "command-output",
+				command: "node",
+				args: ["--version"],
+			});
+			expect(result.type).toBe("command-output");
+			expect(result).not.toHaveProperty("expectContains");
+		});
+
+		it("accepts pip-package strategy", () => {
+			const result = VerifyStrategySchema.parse({ type: "pip-package", name: "requests" });
+			expect(result).toEqual({ type: "pip-package", name: "requests" });
+		});
+
+		it("accepts cargo-crate strategy", () => {
+			const result = VerifyStrategySchema.parse({ type: "cargo-crate", name: "ripgrep" });
+			expect(result).toEqual({ type: "cargo-crate", name: "ripgrep" });
+		});
+
+		it("accepts npm-package strategy", () => {
+			const result = VerifyStrategySchema.parse({ type: "npm-package", name: "typescript" });
+			expect(result).toEqual({ type: "npm-package", name: "typescript" });
+		});
+
+		it("rejects unknown strategy type", () => {
+			expect(() => VerifyStrategySchema.parse({ type: "shell-command", cmd: "which git" })).toThrow();
+		});
+
+		it("rejects free-form string (old format)", () => {
+			expect(() => VerifyStrategySchema.parse("which git")).toThrow();
+		});
+	});
+
+	describe("PostInstallActionSchema", () => {
+		it("accepts none action", () => {
+			expect(PostInstallActionSchema.parse({ type: "none" })).toEqual({ type: "none" });
+		});
+
+		it("accepts run-command action", () => {
+			const result = PostInstallActionSchema.parse({
+				type: "run-command",
+				command: "rustup",
+				args: ["update"],
+			});
+			expect(result).toEqual({ type: "run-command", command: "rustup", args: ["update"] });
+		});
+
+		it("rejects free-form string (old format)", () => {
+			expect(() => PostInstallActionSchema.parse("rustup update")).toThrow();
+		});
+
+		it("rejects unknown action type", () => {
+			expect(() => PostInstallActionSchema.parse({ type: "exec", cmd: "pip install x" })).toThrow();
+		});
+	});
+
+	describe("ToolEntrySchema", () => {
+		it("parses a valid entry with binary-exists verify", () => {
+			const result = ToolEntrySchema.parse({
+				name: "git",
+				type: "system",
+				verify: { type: "binary-exists", name: "git" },
+			});
+			expect(result.name).toBe("git");
+			expect(result.type).toBe("system");
+			expect(result.required).toBe(true);
+			expect(result.postInstall).toEqual({ type: "none" });
+		});
+
+		it("defaults postInstall to { type: 'none' }", () => {
+			const result = ToolEntrySchema.parse({
+				name: "git",
+				type: "system",
+				verify: { type: "binary-exists", name: "git" },
+			});
+			expect(result.postInstall).toEqual({ type: "none" });
+		});
+
+		it("defaults required to true", () => {
+			const result = ToolEntrySchema.parse({
+				name: "git",
+				type: "system",
+				verify: { type: "binary-exists", name: "git" },
+			});
+			expect(result.required).toBe(true);
+		});
+
+		it("allows required: false", () => {
+			const result = ToolEntrySchema.parse({
+				name: "git",
+				type: "system",
+				required: false,
+				verify: { type: "binary-exists", name: "git" },
+			});
+			expect(result.required).toBe(false);
+		});
+
+		it("accepts optional fields: package, marketplace, version", () => {
+			const result = ToolEntrySchema.parse({
+				name: "rg",
+				type: "cargo",
+				package: "ripgrep",
+				marketplace: "crates.io",
+				version: "14.0.0",
+				verify: { type: "binary-exists", name: "rg" },
+			});
+			expect(result.package).toBe("ripgrep");
+			expect(result.marketplace).toBe("crates.io");
+			expect(result.version).toBe("14.0.0");
+		});
+
+		it("rejects entry without name", () => {
+			expect(() =>
+				ToolEntrySchema.parse({
+					type: "system",
+					verify: { type: "binary-exists", name: "git" },
+				}),
+			).toThrow();
+		});
+
+		it("rejects entry with unknown type", () => {
+			expect(() =>
+				ToolEntrySchema.parse({
+					name: "homebrew",
+					type: "brew",
+					verify: { type: "binary-exists", name: "brew" },
+				}),
+			).toThrow();
+		});
+
+		describe(".refine() - command-output verify constraint", () => {
+			it("accepts when verify.command matches tool name", () => {
+				const result = ToolEntrySchema.parse({
+					name: "node",
+					type: "system",
+					verify: {
+						type: "command-output",
+						command: "node",
+						args: ["--version"],
+					},
+				});
+				expect(result.name).toBe("node");
+			});
+
+			it("accepts when verify.command matches tool package", () => {
+				const result = ToolEntrySchema.parse({
+					name: "rg",
+					type: "cargo",
+					package: "ripgrep",
+					verify: {
+						type: "command-output",
+						command: "ripgrep",
+						args: ["--version"],
+					},
+				});
+				expect(result.name).toBe("rg");
+			});
+
+			it("rejects when verify.command does not match name or package", () => {
+				expect(() =>
+					ToolEntrySchema.parse({
+						name: "rg",
+						type: "cargo",
+						package: "ripgrep",
+						verify: {
+							type: "command-output",
+							command: "sh",
+							args: ["-c", "rg --version"],
+						},
+					}),
+				).toThrow("verify/postInstall commands must reference the tool's own binary");
+			});
+		});
+
+		describe(".refine() - run-command postInstall constraint", () => {
+			it("accepts when postInstall.command matches tool name", () => {
+				const result = ToolEntrySchema.parse({
+					name: "rustup",
+					type: "system",
+					verify: { type: "binary-exists", name: "rustup" },
+					postInstall: { type: "run-command", command: "rustup", args: ["update"] },
+				});
+				expect(result.postInstall).toEqual({
+					type: "run-command",
+					command: "rustup",
+					args: ["update"],
+				});
+			});
+
+			it("accepts when postInstall.command matches tool package", () => {
+				const result = ToolEntrySchema.parse({
+					name: "rg",
+					type: "cargo",
+					package: "ripgrep",
+					verify: { type: "binary-exists", name: "rg" },
+					postInstall: { type: "run-command", command: "ripgrep", args: ["--update"] },
+				});
+				expect(result.postInstall).toEqual({
+					type: "run-command",
+					command: "ripgrep",
+					args: ["--update"],
+				});
+			});
+
+			it("rejects when postInstall.command does not match name or package", () => {
+				expect(() =>
+					ToolEntrySchema.parse({
+						name: "rg",
+						type: "cargo",
+						package: "ripgrep",
+						verify: { type: "binary-exists", name: "rg" },
+						postInstall: { type: "run-command", command: "bash", args: ["-c", "rg --update"] },
+					}),
+				).toThrow("verify/postInstall commands must reference the tool's own binary");
+			});
+		});
+	});
+
+	describe("ToolManifestSchema", () => {
+		const validManifest = {
+			version: 1 as const,
+			discoveredAt: BASE_DATE,
+			sourcePlatform: "darwin" as const,
+			tools: [
+				{
+					name: "git",
+					type: "system" as const,
+					verify: { type: "binary-exists" as const, name: "git" },
+				},
+			],
+		};
+
+		it("parses a valid manifest", () => {
+			const result = ToolManifestSchema.parse(validManifest);
+			expect(result.version).toBe(1);
+			expect(result.sourcePlatform).toBe("darwin");
+			expect(result.tools).toHaveLength(1);
+		});
+
+		it("defaults autoInstall to false", () => {
+			const result = ToolManifestSchema.parse(validManifest);
+			expect(result.autoInstall).toBe(false);
+		});
+
+		it("accepts autoInstall: true", () => {
+			const result = ToolManifestSchema.parse({ ...validManifest, autoInstall: true });
+			expect(result.autoInstall).toBe(true);
+		});
+
+		it("rejects version other than 1", () => {
+			expect(() => ToolManifestSchema.parse({ ...validManifest, version: 2 })).toThrow();
+		});
+
+		it("rejects invalid discoveredAt (non-datetime string)", () => {
+			expect(() =>
+				ToolManifestSchema.parse({ ...validManifest, discoveredAt: "not-a-date" }),
+			).toThrow();
+		});
+
+		it("rejects unknown sourcePlatform", () => {
+			expect(() =>
+				ToolManifestSchema.parse({ ...validManifest, sourcePlatform: "freebsd" }),
+			).toThrow();
+		});
+
+		it("accepts linux and win32 platforms", () => {
+			expect(
+				ToolManifestSchema.parse({ ...validManifest, sourcePlatform: "linux" }).sourcePlatform,
+			).toBe("linux");
+			expect(
+				ToolManifestSchema.parse({ ...validManifest, sourcePlatform: "win32" }).sourcePlatform,
+			).toBe("win32");
+		});
+
+		it("accepts an empty tools array", () => {
+			const result = ToolManifestSchema.parse({ ...validManifest, tools: [] });
+			expect(result.tools).toHaveLength(0);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- **Fragment Model**: Split monolithic CLAUDE.md into modular fragments with `@`-references. Shared standards (`shared/standards/`) referenced by all tools, tool-specific orchestration in `claude/orchestration/`. `FragmentCapable` optional interface — only `ClaudeEnvironment` implements it. New `ai-sync fragment split|status|add|remove` CLI command group.

- **Auto-Discovery & Provisioning**: Detect installed tools (pip, cargo, npm, Claude plugins, MCP servers) during `push`, generate typed manifest (`tools/manifest.json`). On `pull`/`bootstrap`, preflight check, show install summary, confirm, install. Typed verification strategies (discriminated union) prevent command injection — no free-form shell strings in manifests. `autoInstall` defaults to `false`.

- **v3 Repo Format**: Explicit `.sync-version` marker for repos using fragments or provisioning. Auto-upgrade from v2 on first use. Compatibility checks for older clients.

- **Convention Fix**: All `addFiles(*, ["."])` calls replaced with explicit file lists (3 locations: sync-engine, migration, init).

### Key Design Decisions
- `FragmentCapable` optional interface, not on base `Environment`
- Typed `VerifyStrategySchema` with `.refine()` enforcing command matches tool name
- Best-effort rollback for tool installs, atomic for config files
- `shared/` directory lives only in sync repo, handled outside per-env loop
- Codex excluded from fragments (uses `config.toml`, not AGENTS.md)

### New Files
| File | Purpose |
|------|---------|
| `src/core/fragmenter.ts` | Markdown splitting, index generation, conflict detection |
| `src/core/tool-manifest.ts` | Zod schemas with typed verification strategies |
| `src/core/provisioner.ts` | Tool discovery, installation, rollback |
| `src/core/provision-config.ts` | Provisioning config with safe defaults |
| `src/cli/commands/fragment.ts` | Fragment CLI (split/status/add/remove) |

### New CLI Commands & Flags
- `ai-sync fragment split|status|add|remove`
- `ai-sync push --skip-discovery`
- `ai-sync pull --no-provision`
- `ai-sync bootstrap --no-provision`
- `ai-sync status` now shows tool installation status

## Test plan

- [x] 124 new tests across 8 test files
- [x] TypeScript strict mode — 0 errors
- [x] Build (tsup) — clean
- [x] Biome lint — 0 errors
- [x] 618/620 tests pass (2 pre-existing flaky failures in link/init integration tests)
- [ ] Manual: run `ai-sync fragment split` on existing CLAUDE.md
- [ ] Manual: run `ai-sync push` and verify `tools/manifest.json` generated
- [ ] Manual: run `ai-sync pull` on second machine and verify provisioning prompt
- [ ] Manual: verify rollback on simulated failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)