### PR TITLE
feat(merge): MergeResolver interface + claude-cli adapter + staging

### DIFF
--- a/src/core/merge/adapters/claude-cli.ts
+++ b/src/core/merge/adapters/claude-cli.ts
@@ -1,0 +1,142 @@
+import * as childProcess from "node:child_process";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { promisify } from "node:util";
+import { buildMergePrompt } from "../prompts.js";
+import {
+	type MergeInput,
+	type MergeOutput,
+	type MergeResolver,
+	ResolverError,
+} from "../resolver.js";
+
+const execFileAsync = promisify(childProcess.execFile);
+
+/**
+ * Execution function shape — mirrors src/core/provisioner.ts:9 ExecFn but
+ * accepts AbortSignal so the adapter can enforce a hard timeout.
+ */
+export type ExecFn = (
+	cmd: string,
+	args: string[],
+	options?: { signal?: AbortSignal },
+) => Promise<{ stdout: string; stderr: string }>;
+
+export function defaultExecFn(
+	cmd: string,
+	args: string[],
+	options?: { signal?: AbortSignal },
+): Promise<{ stdout: string; stderr: string }> {
+	return execFileAsync(cmd, args, { signal: options?.signal });
+}
+
+export interface ClaudeAdapterOptions {
+	/** Hard timeout in milliseconds for `resolve()`. Default 60_000. */
+	timeoutMs?: number;
+	/** Override the claude binary name (default "claude"). */
+	binary?: string;
+	/** Tempdir factory; defaults to os.tmpdir(). */
+	tmpdirRoot?: string;
+}
+
+/**
+ * Creates a MergeResolver backed by the `claude` CLI.
+ *
+ * `available()` runs `claude --version` via the injected execFn.
+ * `resolve()` writes the prompt to a tempdir, invokes `claude -p <file>`,
+ * and returns stdout as the merged content. A hard timeout is enforced via
+ * AbortController. On success the tempdir is cleaned up; on failure it is
+ * preserved and the path is surfaced via ResolverError.tempdir.
+ */
+export function createClaudeAdapter(
+	execFn: ExecFn = defaultExecFn,
+	options: ClaudeAdapterOptions = {},
+): MergeResolver {
+	const timeoutMs = options.timeoutMs ?? 60_000;
+	const binary = options.binary ?? "claude";
+	const tmpdirRoot = options.tmpdirRoot ?? os.tmpdir();
+
+	return {
+		name: "claude",
+		async available(): Promise<boolean> {
+			try {
+				await execFn(binary, ["--version"]);
+				return true;
+			} catch {
+				return false;
+			}
+		},
+		async resolve(input: MergeInput): Promise<MergeOutput> {
+			const id = crypto.randomBytes(6).toString("hex");
+			const tempdir = path.join(tmpdirRoot, `ai-sync-merge-${process.pid}-${id}`);
+			await fs.mkdir(tempdir, { recursive: true });
+
+			const promptFile = path.join(tempdir, "prompt.txt");
+			const prompt = buildMergePrompt(
+				input.relativePath,
+				input.base,
+				input.local,
+				input.remote,
+				input.fileType,
+			);
+			try {
+				await fs.writeFile(promptFile, prompt, "utf-8");
+				// Preserve base/local/remote for postmortem
+				if (input.base !== null) {
+					await fs.writeFile(path.join(tempdir, "base.txt"), input.base, "utf-8");
+				}
+				await fs.writeFile(path.join(tempdir, "local.txt"), input.local, "utf-8");
+				await fs.writeFile(path.join(tempdir, "remote.txt"), input.remote, "utf-8");
+			} catch (err) {
+				throw new ResolverError(
+					"io-error",
+					`Failed to prepare tempdir ${tempdir}: ${(err as Error).message}`,
+					{ tempdir, cause: err },
+				);
+			}
+
+			const controller = new AbortController();
+			const timer = setTimeout(() => controller.abort(), timeoutMs);
+			let result: { stdout: string; stderr: string };
+			try {
+				result = await execFn(binary, ["-p", promptFile], { signal: controller.signal });
+			} catch (err) {
+				const e = err as NodeJS.ErrnoException & { code?: string; killed?: boolean };
+				if (controller.signal.aborted || e.code === "ABORT_ERR" || e.name === "AbortError") {
+					throw new ResolverError(
+						"timeout",
+						`claude exceeded timeout of ${timeoutMs}ms (tempdir: ${tempdir})`,
+						{ tempdir, cause: err },
+					);
+				}
+				throw new ResolverError(
+					"non-zero-exit",
+					`claude exited non-zero: ${(err as Error).message} (tempdir: ${tempdir})`,
+					{ tempdir, cause: err },
+				);
+			} finally {
+				clearTimeout(timer);
+			}
+
+			const merged = result.stdout;
+			if (typeof merged !== "string" || merged.length === 0) {
+				throw new ResolverError(
+					"malformed-output",
+					`claude returned empty stdout (tempdir: ${tempdir})`,
+					{ tempdir },
+				);
+			}
+
+			// Success: cleanup tempdir.
+			try {
+				await fs.rm(tempdir, { recursive: true, force: true });
+			} catch {
+				// Best-effort cleanup; ignore failures.
+			}
+
+			return { mergedContent: merged };
+		},
+	};
+}

--- a/src/core/merge/adapters/index.ts
+++ b/src/core/merge/adapters/index.ts
@@ -1,0 +1,22 @@
+import type { MergeResolver } from "../resolver.js";
+import { createClaudeAdapter, type ExecFn } from "./claude-cli.js";
+
+export type AdapterName = "claude" | "codex" | "opencode";
+
+/**
+ * Factory registry mapping adapter names to constructors.
+ * codex and opencode adapters land in issues #25 and #26.
+ */
+export function createAdapter(name: AdapterName, execFn?: ExecFn): MergeResolver {
+	switch (name) {
+		case "claude":
+			return createClaudeAdapter(execFn);
+		case "codex":
+		case "opencode":
+			throw new Error(`Adapter "${name}" not implemented yet (tracked by issues #25/#26)`);
+		default: {
+			const exhaustive: never = name;
+			throw new Error(`Unknown adapter: ${String(exhaustive)}`);
+		}
+	}
+}

--- a/src/core/merge/config.ts
+++ b/src/core/merge/config.ts
@@ -1,0 +1,56 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { z } from "zod";
+
+/**
+ * Schema for `tools/merge-config.json` in the sync repo.
+ *
+ * `enabled` defaults to false in v1 — flipping the flag is its own issue.
+ * When false, tryAiMerge short-circuits to fallback (keep-local).
+ */
+export const MergeConfigSchema = z.object({
+	enabled: z.boolean().default(false),
+	resolver: z.enum(["claude", "codex", "opencode"]).default("claude"),
+	autoApply: z.boolean().default(false),
+	timeoutSeconds: z.number().int().positive().default(60),
+	perType: z.record(z.string(), z.string()).default(() => ({
+		"*.md": "ai-freeform",
+		"*.json": "ai-validated",
+		"*.yaml": "ai-validated",
+		"*.yml": "ai-validated",
+		"*.lock": "keep-local",
+		"*": "keep-local",
+	})),
+});
+
+export type MergeConfig = z.infer<typeof MergeConfigSchema>;
+
+/**
+ * Loads `<syncRepoDir>/tools/merge-config.json`. If the file is absent,
+ * returns the schema defaults. If the file is present but malformed, throws.
+ */
+export async function loadMergeConfig(syncRepoDir: string): Promise<MergeConfig> {
+	const configPath = path.join(syncRepoDir, "tools", "merge-config.json");
+	let raw: string;
+	try {
+		raw = await fs.readFile(configPath, "utf-8");
+	} catch (err) {
+		const code = (err as NodeJS.ErrnoException).code;
+		if (code === "ENOENT") {
+			return MergeConfigSchema.parse({});
+		}
+		throw err;
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (err) {
+		throw new Error(`Invalid JSON in ${configPath}: ${(err as Error).message}`);
+	}
+	return MergeConfigSchema.parse(parsed);
+}
+
+/** Default config (used by callers when the loader isn't appropriate). */
+export function defaultMergeConfig(): MergeConfig {
+	return MergeConfigSchema.parse({});
+}

--- a/src/core/merge/index.ts
+++ b/src/core/merge/index.ts
@@ -1,0 +1,110 @@
+import * as path from "node:path";
+import type { MergeConfig } from "./config.js";
+import { type FileType, type MergeResolver, ResolverError } from "./resolver.js";
+import { type StagedEntry, stage } from "./staging.js";
+
+export type { ExecFn } from "./adapters/claude-cli.js";
+export { createClaudeAdapter, defaultExecFn } from "./adapters/claude-cli.js";
+export type { AdapterName } from "./adapters/index.js";
+export { createAdapter } from "./adapters/index.js";
+export type { MergeConfig } from "./config.js";
+export { defaultMergeConfig, loadMergeConfig, MergeConfigSchema } from "./config.js";
+export { buildMergePrompt } from "./prompts.js";
+export type {
+	FileType,
+	MergeInput,
+	MergeOutput,
+	MergeResolver,
+} from "./resolver.js";
+export { ResolverError } from "./resolver.js";
+export type { StagedEntry, StageInput } from "./staging.js";
+export { ensureGitignoreEntry, listStaged, stage } from "./staging.js";
+
+/** Classify a file by its extension. Content-sniffing is left to #27. */
+export function classifyFile(relativePath: string): FileType {
+	const ext = path.extname(relativePath).toLowerCase();
+	switch (ext) {
+		case ".md":
+		case ".markdown":
+		case ".txt":
+			return { kind: "markdown" };
+		case ".json":
+			return { kind: "json" };
+		case ".yml":
+		case ".yaml":
+			return { kind: "yaml" };
+		default:
+			return { kind: "unknown", extension: ext };
+	}
+}
+
+export interface TryAiMergeInput {
+	relativePath: string;
+	envName: string;
+	base: string | null;
+	local: string;
+	remote: string;
+}
+
+export interface TryAiMergeDeps {
+	config: MergeConfig;
+	resolver: MergeResolver;
+	syncRepoDir: string;
+	/** Optional warning logger for resolver failures (keeps pull non-fatal). */
+	warn?: (message: string) => void;
+}
+
+export type TryMergeResult =
+	| { kind: "staged"; entry: StagedEntry }
+	| { kind: "applied"; mergedContent: string }
+	| { kind: "fallback"; reason: string };
+
+/**
+ * Orchestrates a single conflict resolution attempt.
+ *
+ * Short-circuits to `fallback` immediately when `config.enabled === false`,
+ * preserving byte-identical pre-feature behavior in the keep-local branch.
+ *
+ * On success, the merged content is staged under `.ai-sync/pending/` unless
+ * `config.autoApply` is true, in which case the result is returned as
+ * `applied` (the caller is responsible for writing it to the live target).
+ *
+ * Any resolver failure returns `fallback` with a reason — never throws.
+ */
+export async function tryAiMerge(
+	input: TryAiMergeInput,
+	deps: TryAiMergeDeps,
+): Promise<TryMergeResult> {
+	if (!deps.config.enabled) {
+		return { kind: "fallback", reason: "disabled" };
+	}
+	const fileType = classifyFile(input.relativePath);
+	try {
+		const output = await deps.resolver.resolve({
+			relativePath: input.relativePath,
+			envName: input.envName,
+			base: input.base,
+			local: input.local,
+			remote: input.remote,
+			fileType,
+		});
+		if (deps.config.autoApply) {
+			return { kind: "applied", mergedContent: output.mergedContent };
+		}
+		const entry = await stage(deps.syncRepoDir, {
+			envName: input.envName,
+			relativePath: input.relativePath,
+			mergedContent: output.mergedContent,
+			resolver: deps.resolver.name,
+			notes: output.notes,
+		});
+		return { kind: "staged", entry };
+	} catch (err) {
+		const reason =
+			err instanceof ResolverError ? err.reason : (err as Error)?.message || "unknown-error";
+		deps.warn?.(
+			`AI merge fell back to keep-local for ${input.envName}/${input.relativePath}: ${reason}`,
+		);
+		return { kind: "fallback", reason };
+	}
+}

--- a/src/core/merge/prompts.ts
+++ b/src/core/merge/prompts.ts
@@ -1,0 +1,33 @@
+import type { FileType } from "./resolver.js";
+
+/**
+ * Build the merge prompt presented to the resolver CLI.
+ *
+ * v1 emits a single uniform prompt for all file types. Per-type variation
+ * is the responsibility of issue #27 (strategy dispatcher).
+ */
+export function buildMergePrompt(
+	relativePath: string,
+	base: string | null,
+	local: string,
+	remote: string,
+	fileType: FileType,
+): string {
+	const typeLabel = fileType.kind === "unknown" ? `unknown (${fileType.extension})` : fileType.kind;
+	const baseSection =
+		base === null
+			? "<BASE>\n(no common ancestor — file is new on both sides)\n</BASE>"
+			: `<BASE>\n${base}\n</BASE>`;
+	return [
+		`You are resolving a 3-way merge conflict for the file "${relativePath}" (type: ${typeLabel}).`,
+		"Combine the intent of both sides without losing information.",
+		"Respond with ONLY the merged file contents — no prose, no code fences, no commentary.",
+		"",
+		baseSection,
+		"",
+		`<LOCAL>\n${local}\n</LOCAL>`,
+		"",
+		`<REMOTE>\n${remote}\n</REMOTE>`,
+		"",
+	].join("\n");
+}

--- a/src/core/merge/resolver.ts
+++ b/src/core/merge/resolver.ts
@@ -1,0 +1,63 @@
+/**
+ * MergeResolver interface and types for AI-assisted merge resolution.
+ *
+ * Adapters mirror the ExecFn pattern from src/core/provisioner.ts:7 — they
+ * accept an injected execFn for testability.
+ */
+
+export type FileType =
+	| { kind: "markdown" }
+	| { kind: "json" }
+	| { kind: "yaml" }
+	| { kind: "unknown"; extension: string };
+
+export interface MergeInput {
+	/** Path relative to the env config dir, e.g. "CLAUDE.md". */
+	relativePath: string;
+	/** Environment id, e.g. "claude" | "opencode". */
+	envName: string;
+	/** Last-synced content; null if the file is new. */
+	base: string | null;
+	/** Current on-disk content. */
+	local: string;
+	/** Post-pull content from the sync repo. */
+	remote: string;
+	/** File classification, resolved upstream by strategies.ts (issue #27). */
+	fileType: FileType;
+}
+
+export interface MergeOutput {
+	mergedContent: string;
+	/** Optional rationale from the adapter, surfaced in status reports. */
+	notes?: string;
+}
+
+export interface MergeResolver {
+	readonly name: string;
+	/** Probe whether the underlying CLI is available. */
+	available(): Promise<boolean>;
+	/** Produce a merged version of the input. */
+	resolve(input: MergeInput): Promise<MergeOutput>;
+}
+
+/**
+ * Error class for resolver failures. The `reason` field is a short tag
+ * used by the orchestrator to decide fallback behavior.
+ */
+export class ResolverError extends Error {
+	readonly reason: "non-zero-exit" | "timeout" | "malformed-output" | "probe-failed" | "io-error";
+	readonly tempdir?: string;
+	constructor(
+		reason: ResolverError["reason"],
+		message: string,
+		options?: { tempdir?: string; cause?: unknown },
+	) {
+		super(message);
+		this.name = "ResolverError";
+		this.reason = reason;
+		this.tempdir = options?.tempdir;
+		if (options?.cause !== undefined) {
+			(this as { cause?: unknown }).cause = options.cause;
+		}
+	}
+}

--- a/src/core/merge/staging.ts
+++ b/src/core/merge/staging.ts
@@ -1,0 +1,109 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { z } from "zod";
+
+export const StagedEntrySchema = z.object({
+	envName: z.string(),
+	relativePath: z.string(),
+	resolver: z.string(),
+	notes: z.string().optional(),
+	timestamp: z.string(),
+});
+export type StagedEntry = z.infer<typeof StagedEntrySchema>;
+
+const ManifestSchema = z.object({
+	version: z.literal(1).default(1),
+	entries: z.array(StagedEntrySchema).default(() => []),
+});
+type Manifest = z.infer<typeof ManifestSchema>;
+
+const PENDING_DIR = ".ai-sync/pending";
+
+function pendingDir(syncRepoDir: string): string {
+	return path.join(syncRepoDir, PENDING_DIR);
+}
+
+function manifestPath(syncRepoDir: string): string {
+	return path.join(pendingDir(syncRepoDir), "manifest.json");
+}
+
+async function readManifest(syncRepoDir: string): Promise<Manifest> {
+	try {
+		const raw = await fs.readFile(manifestPath(syncRepoDir), "utf-8");
+		return ManifestSchema.parse(JSON.parse(raw));
+	} catch (err) {
+		const code = (err as NodeJS.ErrnoException).code;
+		if (code === "ENOENT") return { version: 1, entries: [] };
+		throw err;
+	}
+}
+
+async function writeManifest(syncRepoDir: string, manifest: Manifest): Promise<void> {
+	await fs.mkdir(pendingDir(syncRepoDir), { recursive: true });
+	await fs.writeFile(manifestPath(syncRepoDir), `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
+}
+
+/**
+ * Appends `.ai-sync/pending/` to the sync repo's `.gitignore` exactly once.
+ * Idempotent: scans existing entries before writing.
+ */
+export async function ensureGitignoreEntry(syncRepoDir: string): Promise<void> {
+	const gitignorePath = path.join(syncRepoDir, ".gitignore");
+	let existing = "";
+	try {
+		existing = await fs.readFile(gitignorePath, "utf-8");
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+	}
+	const lines = existing.split("\n").map((l) => l.trim());
+	const wanted = ".ai-sync/pending/";
+	const wantedAlt = ".ai-sync/pending";
+	if (lines.includes(wanted) || lines.includes(wantedAlt)) return;
+	const sep = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
+	await fs.writeFile(gitignorePath, `${existing}${sep}${wanted}\n`, "utf-8");
+}
+
+export interface StageInput {
+	envName: string;
+	relativePath: string;
+	mergedContent: string;
+	resolver: string;
+	notes?: string;
+}
+
+/**
+ * Writes the merged content under `<syncRepoDir>/.ai-sync/pending/<env>/<rel>`
+ * and appends a manifest entry. Idempotent on (envName, relativePath):
+ * a second call overwrites the file and updates the existing manifest entry.
+ */
+export async function stage(syncRepoDir: string, input: StageInput): Promise<StagedEntry> {
+	await fs.mkdir(pendingDir(syncRepoDir), { recursive: true });
+	await ensureGitignoreEntry(syncRepoDir);
+
+	const filePath = path.join(pendingDir(syncRepoDir), input.envName, input.relativePath);
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, input.mergedContent, "utf-8");
+
+	const entry: StagedEntry = {
+		envName: input.envName,
+		relativePath: input.relativePath,
+		resolver: input.resolver,
+		notes: input.notes,
+		timestamp: new Date().toISOString(),
+	};
+
+	const manifest = await readManifest(syncRepoDir);
+	const idx = manifest.entries.findIndex(
+		(e) => e.envName === input.envName && e.relativePath === input.relativePath,
+	);
+	if (idx >= 0) manifest.entries[idx] = entry;
+	else manifest.entries.push(entry);
+	await writeManifest(syncRepoDir, manifest);
+	return entry;
+}
+
+/** Returns the list of staged merge entries, or an empty array. */
+export async function listStaged(syncRepoDir: string): Promise<StagedEntry[]> {
+	const manifest = await readManifest(syncRepoDir);
+	return manifest.entries;
+}

--- a/src/core/sync-engine.ts
+++ b/src/core/sync-engine.ts
@@ -13,6 +13,11 @@ import {
 import { createBackup } from "./backup.js";
 import { makeAllowlistFn, needsPathRewrite } from "./env-helpers.js";
 import type { Environment } from "./environment.js";
+import { createAdapter } from "./merge/adapters/index.js";
+import { defaultMergeConfig, loadMergeConfig, type MergeConfig } from "./merge/config.js";
+import { tryAiMerge } from "./merge/index.js";
+import type { MergeResolver } from "./merge/resolver.js";
+import type { StagedEntry } from "./merge/staging.js";
 import { detectRepoVersion, migrateToV3 } from "./migration.js";
 import { expandPathsForLocal, rewritePathsForRepo } from "./path-rewriter.js";
 import type { ProvisionResult } from "./provisioner.js";
@@ -96,9 +101,16 @@ export interface SyncPullResult {
 	fileChanges: FileChange[];
 	/** Files skipped because both local and remote had changes (merge conflict). */
 	conflicts?: FileChange[];
+	/** Conflict resolutions staged for review under <syncRepo>/.ai-sync/pending/. */
+	staged?: StagedEntry[];
 	perEnvironment?: Record<
 		string,
-		{ filesApplied: number; fileChanges: FileChange[]; conflicts?: FileChange[] }
+		{
+			filesApplied: number;
+			fileChanges: FileChange[];
+			conflicts?: FileChange[];
+			staged?: StagedEntry[];
+		}
 	>;
 	/** Errors encountered per environment (non-fatal). */
 	errors?: Record<string, string>;
@@ -456,12 +468,39 @@ export async function syncPull(options: SyncOptions): Promise<SyncPullResult> {
 	verboseLog(options, `Repo version: v${version}`);
 	const allFileChanges: FileChange[] = [];
 	const allConflicts: FileChange[] = [];
+	const allStaged: StagedEntry[] = [];
 	let backupDir = "";
 	let totalApplied = 0;
 	const perEnvironment: Record<
 		string,
-		{ filesApplied: number; fileChanges: FileChange[]; conflicts?: FileChange[] }
+		{
+			filesApplied: number;
+			fileChanges: FileChange[];
+			conflicts?: FileChange[];
+			staged?: StagedEntry[];
+		}
 	> = {};
+
+	// Load merge config + resolver lazily — defaults disable AI merge.
+	let mergeConfig: MergeConfig;
+	try {
+		mergeConfig = await loadMergeConfig(syncRepoDir);
+	} catch (err) {
+		verboseLog(
+			options,
+			`Invalid tools/merge-config.json — disabling AI merge: ${(err as Error).message}`,
+		);
+		mergeConfig = defaultMergeConfig();
+	}
+	let mergeResolver: MergeResolver | undefined;
+	if (mergeConfig.enabled) {
+		try {
+			mergeResolver = createAdapter(mergeConfig.resolver);
+		} catch (err) {
+			verboseLog(options, `Failed to construct adapter: ${(err as Error).message}`);
+			mergeConfig = { ...mergeConfig, enabled: false };
+		}
+	}
 	const errors: Record<string, string> = {};
 	const envs = options.filterEnv
 		? (options.environments ?? []).filter((e) => e.id === options.filterEnv)
@@ -535,6 +574,7 @@ export async function syncPull(options: SyncOptions): Promise<SyncPullResult> {
 				const allowlistFn = makeAllowlistFn(env);
 				const envChanges: FileChange[] = [];
 				const envConflicts: FileChange[] = [];
+				const envStaged: StagedEntry[] = [];
 				const prePull = prePullContents.get(env.id) ?? new Map<string, string>();
 
 				let repoFiles: string[] = [];
@@ -630,13 +670,50 @@ export async function syncPull(options: SyncOptions): Promise<SyncPullResult> {
 								type: "modified",
 							});
 						} else {
-							// Both changed — conflict, keep local version
-							verboseLog(options, `Conflict (keeping local): ${relativePath}`);
-							envConflicts.push({ path: relativePath, type: "modified" });
-							allConflicts.push({
-								path: `${env.id}/${relativePath}`,
-								type: "modified",
-							});
+							// Both changed — conflict. Try AI-assisted merge if enabled;
+							// otherwise (or on any resolver failure) fall back to keep-local.
+							let aiHandled = false;
+							if (mergeConfig.enabled && mergeResolver) {
+								const merge = await tryAiMerge(
+									{
+										relativePath,
+										envName: env.id,
+										base: baseContent,
+										local: localContent,
+										remote: remoteContent,
+									},
+									{
+										config: mergeConfig,
+										resolver: mergeResolver,
+										syncRepoDir,
+										warn: (m) => verboseLog(options, m),
+									},
+								);
+								if (merge.kind === "staged") {
+									envStaged.push(merge.entry);
+									allStaged.push(merge.entry);
+									aiHandled = true;
+								} else if (merge.kind === "applied") {
+									if (!options.dryRun) {
+										await fs.mkdir(path.dirname(destPath), { recursive: true });
+										await writeFilePreservingMode(srcPath, destPath, merge.mergedContent);
+									}
+									envChanges.push({ path: relativePath, type: "modified" });
+									allFileChanges.push({
+										path: `${env.id}/${relativePath}`,
+										type: "modified",
+									});
+									aiHandled = true;
+								}
+							}
+							if (!aiHandled) {
+								verboseLog(options, `Conflict (keeping local): ${relativePath}`);
+								envConflicts.push({ path: relativePath, type: "modified" });
+								allConflicts.push({
+									path: `${env.id}/${relativePath}`,
+									type: "modified",
+								});
+							}
 						}
 					}
 				}
@@ -699,6 +776,7 @@ export async function syncPull(options: SyncOptions): Promise<SyncPullResult> {
 					filesApplied: repoFiles.length,
 					fileChanges: envChanges,
 					conflicts: envConflicts.length > 0 ? envConflicts : undefined,
+					staged: envStaged.length > 0 ? envStaged : undefined,
 				};
 			} catch (err) {
 				errors[env.id] = err instanceof Error ? err.message : String(err);
@@ -871,7 +949,9 @@ export async function syncPull(options: SyncOptions): Promise<SyncPullResult> {
 			// No manifest or invalid — log in verbose mode
 			if (options.verbose) {
 				console.warn(
-					pc.yellow(`  [verbose] Provisioning skipped: ${provErr instanceof Error ? provErr.message : String(provErr)}`),
+					pc.yellow(
+						`  [verbose] Provisioning skipped: ${provErr instanceof Error ? provErr.message : String(provErr)}`,
+					),
 				);
 			}
 		}
@@ -885,6 +965,7 @@ export async function syncPull(options: SyncOptions): Promise<SyncPullResult> {
 			: `Applied ${totalApplied} files from remote. Backup at: ${backupDir}${conflictSuffix}`,
 		fileChanges: allFileChanges,
 		conflicts: allConflicts.length > 0 ? allConflicts : undefined,
+		staged: allStaged.length > 0 ? allStaged : undefined,
 		perEnvironment: Object.keys(perEnvironment).length > 0 ? perEnvironment : undefined,
 		errors: hasErrors ? errors : undefined,
 		dryRun: options.dryRun,

--- a/tests/core/merge/config.test.ts
+++ b/tests/core/merge/config.test.ts
@@ -1,0 +1,75 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { defaultMergeConfig, loadMergeConfig } from "../../../src/core/merge/config.js";
+
+let syncRepoDir: string;
+
+beforeEach(async () => {
+	syncRepoDir = await fs.mkdtemp(path.join(os.tmpdir(), "ai-sync-config-test-"));
+});
+
+afterEach(async () => {
+	await fs.rm(syncRepoDir, { recursive: true, force: true });
+});
+
+describe("loadMergeConfig()", () => {
+	it("returns schema defaults when the file is absent", async () => {
+		const cfg = await loadMergeConfig(syncRepoDir);
+		expect(cfg.enabled).toBe(false);
+		expect(cfg.resolver).toBe("claude");
+		expect(cfg.autoApply).toBe(false);
+		expect(cfg.timeoutSeconds).toBe(60);
+		expect(cfg.perType["*.md"]).toBe("ai-freeform");
+	});
+
+	it("merges partial config with defaults", async () => {
+		await fs.mkdir(path.join(syncRepoDir, "tools"), { recursive: true });
+		await fs.writeFile(
+			path.join(syncRepoDir, "tools", "merge-config.json"),
+			JSON.stringify({ enabled: true, resolver: "codex" }),
+			"utf-8",
+		);
+		const cfg = await loadMergeConfig(syncRepoDir);
+		expect(cfg.enabled).toBe(true);
+		expect(cfg.resolver).toBe("codex");
+		expect(cfg.autoApply).toBe(false); // still default
+		expect(cfg.timeoutSeconds).toBe(60); // still default
+	});
+
+	it("throws on invalid JSON", async () => {
+		await fs.mkdir(path.join(syncRepoDir, "tools"), { recursive: true });
+		await fs.writeFile(path.join(syncRepoDir, "tools", "merge-config.json"), "{not json", "utf-8");
+		await expect(loadMergeConfig(syncRepoDir)).rejects.toThrow(/Invalid JSON/);
+	});
+
+	it("throws on schema mismatch (e.g. unknown resolver)", async () => {
+		await fs.mkdir(path.join(syncRepoDir, "tools"), { recursive: true });
+		await fs.writeFile(
+			path.join(syncRepoDir, "tools", "merge-config.json"),
+			JSON.stringify({ resolver: "gpt" }),
+			"utf-8",
+		);
+		await expect(loadMergeConfig(syncRepoDir)).rejects.toThrow();
+	});
+
+	it("throws on negative timeout", async () => {
+		await fs.mkdir(path.join(syncRepoDir, "tools"), { recursive: true });
+		await fs.writeFile(
+			path.join(syncRepoDir, "tools", "merge-config.json"),
+			JSON.stringify({ timeoutSeconds: -1 }),
+			"utf-8",
+		);
+		await expect(loadMergeConfig(syncRepoDir)).rejects.toThrow();
+	});
+});
+
+describe("defaultMergeConfig()", () => {
+	it("returns the same defaults as the loader for an absent file", () => {
+		const cfg = defaultMergeConfig();
+		expect(cfg.enabled).toBe(false);
+		expect(cfg.resolver).toBe("claude");
+		expect(cfg.timeoutSeconds).toBe(60);
+	});
+});

--- a/tests/core/merge/orchestrator.test.ts
+++ b/tests/core/merge/orchestrator.test.ts
@@ -1,0 +1,143 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { defaultMergeConfig } from "../../../src/core/merge/config.js";
+import { classifyFile, tryAiMerge } from "../../../src/core/merge/index.js";
+import type { MergeResolver } from "../../../src/core/merge/resolver.js";
+import { listStaged } from "../../../src/core/merge/staging.js";
+
+let syncRepoDir: string;
+
+beforeEach(async () => {
+	syncRepoDir = await fs.mkdtemp(path.join(os.tmpdir(), "ai-sync-orch-test-"));
+});
+
+afterEach(async () => {
+	await fs.rm(syncRepoDir, { recursive: true, force: true });
+});
+
+function stubResolver(content: string): MergeResolver {
+	return {
+		name: "stub",
+		async available() {
+			return true;
+		},
+		async resolve() {
+			return { mergedContent: content };
+		},
+	};
+}
+
+describe("classifyFile()", () => {
+	it("identifies markdown by extension", () => {
+		expect(classifyFile("CLAUDE.md").kind).toBe("markdown");
+		expect(classifyFile("a.markdown").kind).toBe("markdown");
+		expect(classifyFile("notes.txt").kind).toBe("markdown");
+	});
+	it("identifies json/yaml/unknown", () => {
+		expect(classifyFile("a.json").kind).toBe("json");
+		expect(classifyFile("a.yaml").kind).toBe("yaml");
+		expect(classifyFile("a.yml").kind).toBe("yaml");
+		const u = classifyFile("Makefile");
+		expect(u.kind).toBe("unknown");
+		expect(u.kind === "unknown" && u.extension).toBe("");
+	});
+});
+
+describe("tryAiMerge()", () => {
+	it("short-circuits to fallback when config.enabled is false", async () => {
+		const cfg = defaultMergeConfig();
+		expect(cfg.enabled).toBe(false);
+		let called = false;
+		const resolver: MergeResolver = {
+			name: "spy",
+			async available() {
+				return true;
+			},
+			async resolve() {
+				called = true;
+				return { mergedContent: "x" };
+			},
+		};
+		const result = await tryAiMerge(
+			{
+				relativePath: "CLAUDE.md",
+				envName: "claude",
+				base: "B",
+				local: "L",
+				remote: "R",
+			},
+			{ config: cfg, resolver, syncRepoDir },
+		);
+		expect(result.kind).toBe("fallback");
+		expect(result.kind === "fallback" && result.reason).toBe("disabled");
+		expect(called).toBe(false);
+	});
+
+	it("stages merged content when enabled and autoApply=false", async () => {
+		const cfg = { ...defaultMergeConfig(), enabled: true };
+		const result = await tryAiMerge(
+			{
+				relativePath: "CLAUDE.md",
+				envName: "claude",
+				base: "B",
+				local: "L",
+				remote: "R",
+			},
+			{ config: cfg, resolver: stubResolver("MERGED"), syncRepoDir },
+		);
+		expect(result.kind).toBe("staged");
+		const staged = await listStaged(syncRepoDir);
+		expect(staged).toHaveLength(1);
+		const file = await fs.readFile(
+			path.join(syncRepoDir, ".ai-sync", "pending", "claude", "CLAUDE.md"),
+			"utf-8",
+		);
+		expect(file).toBe("MERGED");
+	});
+
+	it("returns applied (no stage) when autoApply=true", async () => {
+		const cfg = { ...defaultMergeConfig(), enabled: true, autoApply: true };
+		const result = await tryAiMerge(
+			{
+				relativePath: "CLAUDE.md",
+				envName: "claude",
+				base: null,
+				local: "L",
+				remote: "R",
+			},
+			{ config: cfg, resolver: stubResolver("MERGED"), syncRepoDir },
+		);
+		expect(result.kind).toBe("applied");
+		expect(result.kind === "applied" && result.mergedContent).toBe("MERGED");
+		const staged = await listStaged(syncRepoDir);
+		expect(staged).toHaveLength(0);
+	});
+
+	it("returns fallback when the resolver throws — never propagates", async () => {
+		const cfg = { ...defaultMergeConfig(), enabled: true };
+		const resolver: MergeResolver = {
+			name: "boom",
+			async available() {
+				return true;
+			},
+			async resolve() {
+				throw new Error("kaboom");
+			},
+		};
+		const warnings: string[] = [];
+		const result = await tryAiMerge(
+			{
+				relativePath: "CLAUDE.md",
+				envName: "claude",
+				base: null,
+				local: "L",
+				remote: "R",
+			},
+			{ config: cfg, resolver, syncRepoDir, warn: (m) => warnings.push(m) },
+		);
+		expect(result.kind).toBe("fallback");
+		expect(warnings.length).toBe(1);
+	});
+});

--- a/tests/core/merge/resolver.test.ts
+++ b/tests/core/merge/resolver.test.ts
@@ -1,0 +1,196 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createClaudeAdapter, type ExecFn } from "../../../src/core/merge/adapters/claude-cli.js";
+import { ResolverError } from "../../../src/core/merge/resolver.js";
+
+let tmpRoot: string;
+
+beforeEach(async () => {
+	tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "ai-sync-merge-test-"));
+});
+
+afterEach(async () => {
+	await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe("createClaudeAdapter", () => {
+	describe("available()", () => {
+		it("returns true when claude --version succeeds", async () => {
+			const execFn: ExecFn = async (cmd, args) => {
+				expect(cmd).toBe("claude");
+				expect(args).toEqual(["--version"]);
+				return { stdout: "claude 1.0.0\n", stderr: "" };
+			};
+			const adapter = createClaudeAdapter(execFn);
+			expect(await adapter.available()).toBe(true);
+		});
+
+		it("returns false when claude --version throws", async () => {
+			const execFn: ExecFn = async () => {
+				throw new Error("ENOENT");
+			};
+			const adapter = createClaudeAdapter(execFn);
+			expect(await adapter.available()).toBe(false);
+		});
+	});
+
+	describe("resolve()", () => {
+		it("returns stdout as mergedContent on success", async () => {
+			const execFn: ExecFn = async (cmd, args) => {
+				expect(cmd).toBe("claude");
+				expect(args[0]).toBe("-p");
+				// args[1] should be a tempdir-scoped prompt file
+				expect(args[1]).toContain("prompt.txt");
+				const promptContent = await fs.readFile(args[1], "utf-8");
+				expect(promptContent).toContain("CLAUDE.md");
+				expect(promptContent).toContain("local body");
+				expect(promptContent).toContain("remote body");
+				return { stdout: "merged body", stderr: "" };
+			};
+			const adapter = createClaudeAdapter(execFn, { tmpdirRoot: tmpRoot });
+			const out = await adapter.resolve({
+				relativePath: "CLAUDE.md",
+				envName: "claude",
+				base: "base body",
+				local: "local body",
+				remote: "remote body",
+				fileType: { kind: "markdown" },
+			});
+			expect(out.mergedContent).toBe("merged body");
+		});
+
+		it("supports null base (new file on both sides)", async () => {
+			const execFn: ExecFn = async (_cmd, args) => {
+				const promptContent = await fs.readFile(args[1], "utf-8");
+				expect(promptContent).toContain("no common ancestor");
+				return { stdout: "merged", stderr: "" };
+			};
+			const adapter = createClaudeAdapter(execFn, { tmpdirRoot: tmpRoot });
+			const out = await adapter.resolve({
+				relativePath: "new.md",
+				envName: "claude",
+				base: null,
+				local: "L",
+				remote: "R",
+				fileType: { kind: "markdown" },
+			});
+			expect(out.mergedContent).toBe("merged");
+		});
+
+		it("throws ResolverError with reason non-zero-exit on subprocess failure", async () => {
+			const execFn: ExecFn = async () => {
+				const err = new Error("exited with code 1") as NodeJS.ErrnoException;
+				err.code = "1";
+				throw err;
+			};
+			const adapter = createClaudeAdapter(execFn, { tmpdirRoot: tmpRoot });
+			await expect(
+				adapter.resolve({
+					relativePath: "x.md",
+					envName: "claude",
+					base: null,
+					local: "a",
+					remote: "b",
+					fileType: { kind: "markdown" },
+				}),
+			).rejects.toMatchObject({
+				name: "ResolverError",
+				reason: "non-zero-exit",
+			});
+		});
+
+		it("throws ResolverError with reason timeout when signal aborts", async () => {
+			const execFn: ExecFn = async (_cmd, _args, opts) => {
+				return await new Promise((_resolve, reject) => {
+					opts?.signal?.addEventListener("abort", () => {
+						const err = new Error("aborted") as NodeJS.ErrnoException;
+						err.name = "AbortError";
+						err.code = "ABORT_ERR";
+						reject(err);
+					});
+				});
+			};
+			const adapter = createClaudeAdapter(execFn, {
+				tmpdirRoot: tmpRoot,
+				timeoutMs: 25,
+			});
+			await expect(
+				adapter.resolve({
+					relativePath: "x.md",
+					envName: "claude",
+					base: null,
+					local: "a",
+					remote: "b",
+					fileType: { kind: "markdown" },
+				}),
+			).rejects.toMatchObject({
+				name: "ResolverError",
+				reason: "timeout",
+			});
+		});
+
+		it("throws ResolverError with reason malformed-output on empty stdout", async () => {
+			const execFn: ExecFn = async () => ({ stdout: "", stderr: "" });
+			const adapter = createClaudeAdapter(execFn, { tmpdirRoot: tmpRoot });
+			await expect(
+				adapter.resolve({
+					relativePath: "x.md",
+					envName: "claude",
+					base: null,
+					local: "a",
+					remote: "b",
+					fileType: { kind: "markdown" },
+				}),
+			).rejects.toMatchObject({
+				name: "ResolverError",
+				reason: "malformed-output",
+			});
+		});
+
+		it("preserves tempdir on failure with path surfaced via error", async () => {
+			let capturedTempdir: string | undefined;
+			const execFn: ExecFn = async (_cmd, args) => {
+				capturedTempdir = path.dirname(args[1]);
+				throw new Error("boom");
+			};
+			const adapter = createClaudeAdapter(execFn, { tmpdirRoot: tmpRoot });
+			try {
+				await adapter.resolve({
+					relativePath: "x.md",
+					envName: "claude",
+					base: null,
+					local: "a",
+					remote: "b",
+					fileType: { kind: "markdown" },
+				});
+				expect.fail("expected throw");
+			} catch (err) {
+				expect(err).toBeInstanceOf(ResolverError);
+				expect((err as ResolverError).tempdir).toBe(capturedTempdir);
+				// tempdir should still exist for postmortem
+				const stat = await fs.stat(capturedTempdir as string);
+				expect(stat.isDirectory()).toBe(true);
+			}
+		});
+
+		it("cleans up tempdir on success", async () => {
+			let capturedTempdir: string | undefined;
+			const execFn: ExecFn = async (_cmd, args) => {
+				capturedTempdir = path.dirname(args[1]);
+				return { stdout: "merged", stderr: "" };
+			};
+			const adapter = createClaudeAdapter(execFn, { tmpdirRoot: tmpRoot });
+			await adapter.resolve({
+				relativePath: "x.md",
+				envName: "claude",
+				base: null,
+				local: "a",
+				remote: "b",
+				fileType: { kind: "markdown" },
+			});
+			await expect(fs.stat(capturedTempdir as string)).rejects.toMatchObject({ code: "ENOENT" });
+		});
+	});
+});

--- a/tests/core/merge/staging.test.ts
+++ b/tests/core/merge/staging.test.ts
@@ -1,0 +1,145 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ensureGitignoreEntry, listStaged, stage } from "../../../src/core/merge/staging.js";
+
+let syncRepoDir: string;
+
+beforeEach(async () => {
+	syncRepoDir = await fs.mkdtemp(path.join(os.tmpdir(), "ai-sync-staging-test-"));
+});
+
+afterEach(async () => {
+	await fs.rm(syncRepoDir, { recursive: true, force: true });
+});
+
+describe("stage()", () => {
+	it("writes merged content under .ai-sync/pending/<env>/<rel>", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "CLAUDE.md",
+			mergedContent: "merged body",
+			resolver: "claude",
+		});
+		const out = await fs.readFile(
+			path.join(syncRepoDir, ".ai-sync", "pending", "claude", "CLAUDE.md"),
+			"utf-8",
+		);
+		expect(out).toBe("merged body");
+	});
+
+	it("creates nested directories for relative paths with subdirs", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "agents/foo.md",
+			mergedContent: "agent body",
+			resolver: "claude",
+		});
+		const out = await fs.readFile(
+			path.join(syncRepoDir, ".ai-sync", "pending", "claude", "agents", "foo.md"),
+			"utf-8",
+		);
+		expect(out).toBe("agent body");
+	});
+
+	it("writes a manifest entry that round-trips via listStaged()", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "CLAUDE.md",
+			mergedContent: "merged",
+			resolver: "claude",
+			notes: "rationale here",
+		});
+		const entries = await listStaged(syncRepoDir);
+		expect(entries).toHaveLength(1);
+		expect(entries[0]).toMatchObject({
+			envName: "claude",
+			relativePath: "CLAUDE.md",
+			resolver: "claude",
+			notes: "rationale here",
+		});
+		expect(entries[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+	});
+
+	it("is idempotent on (envName, relativePath) — overwrites file and updates entry", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "CLAUDE.md",
+			mergedContent: "first",
+			resolver: "claude",
+		});
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "CLAUDE.md",
+			mergedContent: "second",
+			resolver: "claude",
+		});
+		const entries = await listStaged(syncRepoDir);
+		expect(entries).toHaveLength(1);
+		const file = await fs.readFile(
+			path.join(syncRepoDir, ".ai-sync", "pending", "claude", "CLAUDE.md"),
+			"utf-8",
+		);
+		expect(file).toBe("second");
+	});
+
+	it("appends two distinct (env, path) tuples as separate entries", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "a.md",
+			mergedContent: "A",
+			resolver: "claude",
+		});
+		await stage(syncRepoDir, {
+			envName: "opencode",
+			relativePath: "a.md",
+			mergedContent: "B",
+			resolver: "claude",
+		});
+		const entries = await listStaged(syncRepoDir);
+		expect(entries).toHaveLength(2);
+	});
+
+	it("listStaged returns [] when manifest is absent", async () => {
+		const entries = await listStaged(syncRepoDir);
+		expect(entries).toEqual([]);
+	});
+});
+
+describe("ensureGitignoreEntry()", () => {
+	it("creates .gitignore if absent", async () => {
+		await ensureGitignoreEntry(syncRepoDir);
+		const contents = await fs.readFile(path.join(syncRepoDir, ".gitignore"), "utf-8");
+		expect(contents).toContain(".ai-sync/pending/");
+	});
+
+	it("appends without duplicate when .gitignore exists", async () => {
+		await fs.writeFile(path.join(syncRepoDir, ".gitignore"), "node_modules\n", "utf-8");
+		await ensureGitignoreEntry(syncRepoDir);
+		await ensureGitignoreEntry(syncRepoDir);
+		const contents = await fs.readFile(path.join(syncRepoDir, ".gitignore"), "utf-8");
+		const matches = contents.match(/\.ai-sync\/pending/g);
+		expect(matches).toHaveLength(1);
+		expect(contents).toContain("node_modules");
+	});
+
+	it("treats `.ai-sync/pending` (no trailing slash) as already present", async () => {
+		await fs.writeFile(path.join(syncRepoDir, ".gitignore"), ".ai-sync/pending\n", "utf-8");
+		await ensureGitignoreEntry(syncRepoDir);
+		const contents = await fs.readFile(path.join(syncRepoDir, ".gitignore"), "utf-8");
+		const matches = contents.match(/\.ai-sync\/pending/g);
+		expect(matches).toHaveLength(1);
+	});
+
+	it("is invoked by stage() (one call ensures the gitignore)", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "x.md",
+			mergedContent: "m",
+			resolver: "claude",
+		});
+		const contents = await fs.readFile(path.join(syncRepoDir, ".gitignore"), "utf-8");
+		expect(contents).toContain(".ai-sync/pending/");
+	});
+});

--- a/tests/core/sync-engine.test.ts
+++ b/tests/core/sync-engine.test.ts
@@ -62,11 +62,7 @@ async function createTestEnv(baseDir: string) {
 /**
  * Creates a mock Environment object for v2 multi-environment tests.
  */
-function createMockEnvironment(
-	id: string,
-	displayName: string,
-	configDir: string,
-): Environment {
+function createMockEnvironment(id: string, displayName: string, configDir: string): Environment {
 	return {
 		id,
 		displayName,
@@ -965,10 +961,7 @@ describe("core/sync-engine", () => {
 			expect(result.perEnvironment?.opencode).toBeDefined();
 
 			// Verify files are in subdirectories
-			const claudeMd = await fs.readFile(
-				path.join(syncRepoDir, "claude", "CLAUDE.md"),
-				"utf-8",
-			);
+			const claudeMd = await fs.readFile(path.join(syncRepoDir, "claude", "CLAUDE.md"), "utf-8");
 			expect(claudeMd).toBe("# Claude Config");
 
 			const agentMd = await fs.readFile(
@@ -1002,16 +995,11 @@ describe("core/sync-engine", () => {
 			expect(result.perEnvironment?.opencode).toBeUndefined();
 
 			// Claude files should exist
-			const claudeMd = await fs.readFile(
-				path.join(syncRepoDir, "claude", "CLAUDE.md"),
-				"utf-8",
-			);
+			const claudeMd = await fs.readFile(path.join(syncRepoDir, "claude", "CLAUDE.md"), "utf-8");
 			expect(claudeMd).toBe("# Claude Config");
 
 			// Opencode subdir should NOT exist
-			await expect(
-				fs.access(path.join(syncRepoDir, "opencode")),
-			).rejects.toThrow();
+			await expect(fs.access(path.join(syncRepoDir, "opencode"))).rejects.toThrow();
 		});
 
 		it("skips environments whose config dir does not exist", async () => {
@@ -1095,8 +1083,8 @@ describe("core/sync-engine", () => {
 					(call) => typeof call[0] === "string" && call[0].includes("[verbose]"),
 				);
 				// Should include "Processing environment:" messages
-				const envMessages = verboseCalls.filter(
-					(call) => call[0].includes("Processing environment"),
+				const envMessages = verboseCalls.filter((call) =>
+					call[0].includes("Processing environment"),
 				);
 				expect(envMessages.length).toBeGreaterThan(0);
 			} finally {
@@ -1126,10 +1114,7 @@ describe("core/sync-engine", () => {
 			expect(result.perEnvironment?.opencode).toBeDefined();
 
 			// Verify files were restored
-			const claudeMd = await fs.readFile(
-				path.join(claudeConfigDir, "CLAUDE.md"),
-				"utf-8",
-			);
+			const claudeMd = await fs.readFile(path.join(claudeConfigDir, "CLAUDE.md"), "utf-8");
 			expect(claudeMd).toBe("# Claude Config");
 
 			const agentMd = await fs.readFile(
@@ -1164,10 +1149,7 @@ describe("core/sync-engine", () => {
 			expect(pullResult.filesApplied).toBeGreaterThan(0);
 
 			// settings.json should have expanded paths for the new home
-			const settings = await fs.readFile(
-				path.join(newClaudeDir, "settings.json"),
-				"utf-8",
-			);
+			const settings = await fs.readFile(path.join(newClaudeDir, "settings.json"), "utf-8");
 			expect(settings).toContain(newHomeDir);
 			expect(settings).not.toContain("{{HOME}}");
 		});
@@ -1213,6 +1195,103 @@ describe("core/sync-engine", () => {
 			expect(result.conflicts).toBeDefined();
 			expect(result.conflicts!.length).toBeGreaterThan(0);
 			expect(result.perEnvironment?.claude?.conflicts).toBeDefined();
+		});
+
+		it("v2 conflict with merge-config enabled=false keeps byte-identical keep-local behavior", async () => {
+			const { bareDir, syncRepoDir, claudeConfigDir, options } = await createV2TestEnv(tmpDir);
+
+			// Explicit enabled:false config file — behavior must match the default-absent case.
+			await fs.mkdir(path.join(syncRepoDir, "tools"), { recursive: true });
+			await fs.writeFile(
+				path.join(syncRepoDir, "tools", "merge-config.json"),
+				JSON.stringify({ enabled: false }),
+				"utf-8",
+			);
+			await syncPush(options);
+
+			const cloneDir = path.join(tmpDir, "clone-v2-merge-off");
+			await fs.mkdir(cloneDir, { recursive: true });
+			await simpleGit(cloneDir).clone(bareDir, ".");
+			await simpleGit(cloneDir).addConfig("user.email", "test@test.com");
+			await simpleGit(cloneDir).addConfig("user.name", "Test");
+			await fs.writeFile(path.join(cloneDir, "claude", "CLAUDE.md"), "# Remote off");
+			await addFiles(cloneDir, ["claude/CLAUDE.md"]);
+			await commitFiles(cloneDir, "remote off");
+			await simpleGit(cloneDir).push("origin", "main");
+
+			await fs.writeFile(path.join(claudeConfigDir, "CLAUDE.md"), "# Local off");
+
+			const result = await syncPull(options);
+
+			expect(result.conflicts).toBeDefined();
+			expect(result.conflicts!.length).toBeGreaterThan(0);
+			expect(result.staged).toBeUndefined();
+			// Pending dir should not be created when the flag is off.
+			await expect(fs.access(path.join(syncRepoDir, ".ai-sync", "pending"))).rejects.toThrow();
+			const content = await fs.readFile(path.join(claudeConfigDir, "CLAUDE.md"), "utf-8");
+			expect(content).toBe("# Local off");
+		});
+
+		it("v2 conflict with merge-config enabled=true and stub resolver stages the merge", async () => {
+			// We can't inject a stub adapter through the public syncPull API in v1,
+			// so we point the config at the claude adapter but stub the `claude`
+			// binary via PATH manipulation through env. Easier: write a fake claude
+			// shim into the worktree and prepend it to PATH for the duration of
+			// this test. Cross-platform tradeoff: this test runs only on posix.
+			if (process.platform === "win32") return;
+			const { bareDir, syncRepoDir, claudeConfigDir, options } = await createV2TestEnv(tmpDir);
+
+			// Fake claude shim that always echoes "MERGED-OUTPUT".
+			const shimDir = path.join(tmpDir, "shim-bin");
+			await fs.mkdir(shimDir, { recursive: true });
+			const shimPath = path.join(shimDir, "claude");
+			await fs.writeFile(shimPath, `#!/usr/bin/env bash\necho 'MERGED-OUTPUT'\n`, "utf-8");
+			await fs.chmod(shimPath, 0o755);
+
+			await fs.mkdir(path.join(syncRepoDir, "tools"), { recursive: true });
+			await fs.writeFile(
+				path.join(syncRepoDir, "tools", "merge-config.json"),
+				JSON.stringify({ enabled: true, resolver: "claude" }),
+				"utf-8",
+			);
+			await syncPush(options);
+
+			const cloneDir = path.join(tmpDir, "clone-v2-merge-on");
+			await fs.mkdir(cloneDir, { recursive: true });
+			await simpleGit(cloneDir).clone(bareDir, ".");
+			await simpleGit(cloneDir).addConfig("user.email", "test@test.com");
+			await simpleGit(cloneDir).addConfig("user.name", "Test");
+			await fs.writeFile(path.join(cloneDir, "claude", "CLAUDE.md"), "# Remote on");
+			await addFiles(cloneDir, ["claude/CLAUDE.md"]);
+			await commitFiles(cloneDir, "remote on");
+			await simpleGit(cloneDir).push("origin", "main");
+
+			await fs.writeFile(path.join(claudeConfigDir, "CLAUDE.md"), "# Local on");
+
+			const originalPath = process.env.PATH;
+			process.env.PATH = `${shimDir}${path.delimiter}${originalPath}`;
+			let result: Awaited<ReturnType<typeof syncPull>>;
+			try {
+				result = await syncPull(options);
+			} finally {
+				process.env.PATH = originalPath;
+			}
+
+			expect(result.staged).toBeDefined();
+			expect(result.staged!.length).toBeGreaterThan(0);
+			expect(result.staged![0].envName).toBe("claude");
+			expect(result.staged![0].relativePath).toBe("CLAUDE.md");
+			// Conflicts array should NOT include this file — it was handled by staging.
+			expect(result.conflicts).toBeUndefined();
+
+			const stagedFile = await fs.readFile(
+				path.join(syncRepoDir, ".ai-sync", "pending", "claude", "CLAUDE.md"),
+				"utf-8",
+			);
+			expect(stagedFile.trim()).toBe("MERGED-OUTPUT");
+			// Live config file is still the local version (staged review pattern).
+			const live = await fs.readFile(path.join(claudeConfigDir, "CLAUDE.md"), "utf-8");
+			expect(live).toBe("# Local on");
 		});
 
 		it("force overrides conflicts in v2 pull", async () => {
@@ -1263,13 +1342,9 @@ describe("core/sync-engine", () => {
 			const result = await syncPull(options);
 
 			// Local file should be deleted
-			await expect(
-				fs.access(path.join(claudeConfigDir, "commands", "test.md")),
-			).rejects.toThrow();
+			await expect(fs.access(path.join(claudeConfigDir, "commands", "test.md"))).rejects.toThrow();
 
-			const deletedChange = result.fileChanges.find((c) =>
-				c.path.includes("commands/test.md"),
-			);
+			const deletedChange = result.fileChanges.find((c) => c.path.includes("commands/test.md"));
 			expect(deletedChange).toBeDefined();
 			expect(deletedChange?.type).toBe("deleted");
 		});
@@ -1291,10 +1366,7 @@ describe("core/sync-engine", () => {
 			await commitFiles(cloneDir, "dry run remote change");
 			await simpleGit(cloneDir).push("origin", "main");
 
-			const localBefore = await fs.readFile(
-				path.join(claudeConfigDir, "CLAUDE.md"),
-				"utf-8",
-			);
+			const localBefore = await fs.readFile(path.join(claudeConfigDir, "CLAUDE.md"), "utf-8");
 
 			const result = await syncPull({ ...options, dryRun: true });
 
@@ -1302,10 +1374,7 @@ describe("core/sync-engine", () => {
 			expect(result.message).toContain("Dry run");
 
 			// Local file should NOT have changed
-			const localAfter = await fs.readFile(
-				path.join(claudeConfigDir, "CLAUDE.md"),
-				"utf-8",
-			);
+			const localAfter = await fs.readFile(path.join(claudeConfigDir, "CLAUDE.md"), "utf-8");
 			expect(localAfter).toBe(localBefore);
 		});
 
@@ -1485,9 +1554,7 @@ describe("core/sync-engine", () => {
 			const result = await syncPull({ ...options, force: true });
 
 			// File should be deleted
-			await expect(
-				fs.access(path.join(claudeDir, "agents", "default.md")),
-			).rejects.toThrow();
+			await expect(fs.access(path.join(claudeDir, "agents", "default.md"))).rejects.toThrow();
 			expect(result.conflicts).toBeUndefined();
 		});
 
@@ -1516,8 +1583,7 @@ describe("core/sync-engine", () => {
 				await syncPull({ ...options, verbose: true });
 
 				const verboseCalls = consoleSpy.mock.calls.filter(
-					(call) =>
-						typeof call[0] === "string" && call[0].includes("Conflict (keeping local)"),
+					(call) => typeof call[0] === "string" && call[0].includes("Conflict (keeping local)"),
 				);
 				expect(verboseCalls.length).toBeGreaterThan(0);
 			} finally {


### PR DESCRIPTION
Closes #24.

Foundation for AI-assisted merge: `MergeResolver` interface, `claude-cli` adapter (mirrors `execFileAsync` pattern from `provisioner.ts:7`), staging skeleton at `.ai-sync/pending/`, zod-validated `tools/merge-config.json` loader. `tryAiMerge` wired into `sync-engine` at the both-changed conflict branch behind an `enabled:false` flag — zero behavior change in v1.

See `docs/specs/2026-05-22-ai-merge-resolver-design.md` sections 4.1–4.6.

## What lands

- `src/core/merge/resolver.ts` — `MergeResolver`, `MergeInput`, `MergeOutput`, `FileType`, `ResolverError`.
- `src/core/merge/adapters/claude-cli.ts` — `createClaudeAdapter(execFn)`; probes `claude --version`; invokes `claude -p <prompt-file>` with `AbortController` timeout (default 60s); preserves tempdir on failure.
- `src/core/merge/adapters/index.ts` — factory registry.
- `src/core/merge/staging.ts` — `stage()`, `listStaged()`, manifest.json schema, idempotent `.gitignore` append.
- `src/core/merge/config.ts` — zod schema + loader; defaults `enabled:false`.
- `src/core/merge/prompts.ts` — uniform v1 prompt (per-type variation deferred to #27).
- `src/core/merge/index.ts` — `tryAiMerge()` orchestrator returning `staged | applied | fallback`; short-circuits to `fallback` when disabled.
- `src/core/sync-engine.ts` — conflict branch gated through `tryAiMerge`; `SyncPullResult.staged` and per-env `staged` populated when feature is enabled.

## Tests

- `tests/core/merge/resolver.test.ts` — probe, success, non-zero, timeout, malformed, tempdir cleanup/preservation.
- `tests/core/merge/staging.test.ts` — manifest round-trip, layout, idempotent stage, gitignore append.
- `tests/core/merge/config.test.ts` — defaults, partial merge, invalid JSON, schema mismatch.
- `tests/core/merge/orchestrator.test.ts` — short-circuit, staged, applied (autoApply), fallback on resolver throw.
- `tests/core/sync-engine.test.ts` — `enabled:false` keeps existing keep-local behavior; `enabled:true` with shim claude binary stages the merge.

`npm test -- tests/core/merge tests/core/sync-engine.test.ts` exits 0. Two pre-existing flaky link tests fail on `main` too (timer + tmpdir ENOTEMPTY) and are unrelated.