### PR TITLE
feat(merge): codex-cli adapter

### DIFF
--- a/src/core/merge/adapters/codex-cli.ts
+++ b/src/core/merge/adapters/codex-cli.ts
@@ -1,0 +1,124 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildMergePrompt } from "../prompts.js";
+import {
+	type MergeInput,
+	type MergeOutput,
+	type MergeResolver,
+	ResolverError,
+} from "../resolver.js";
+import { defaultExecFn, type ExecFn } from "./claude-cli.js";
+
+export interface CodexAdapterOptions {
+	/** Hard timeout in milliseconds for `resolve()`. Default 60_000. */
+	timeoutMs?: number;
+	/** Override the codex binary name (default "codex"). */
+	binary?: string;
+	/** Tempdir factory; defaults to os.tmpdir(). */
+	tmpdirRoot?: string;
+}
+
+/**
+ * Creates a MergeResolver backed by the `codex` CLI.
+ *
+ * `available()` runs `codex --version` via the injected execFn.
+ * `resolve()` writes the prompt to a tempdir, invokes
+ * `codex exec --prompt-file <file>`, and returns stdout as the merged
+ * content. A hard timeout is enforced via AbortController. On success the
+ * tempdir is cleaned up; on failure it is preserved and the path is
+ * surfaced via ResolverError.tempdir.
+ */
+export function createCodexAdapter(
+	execFn: ExecFn = defaultExecFn,
+	options: CodexAdapterOptions = {},
+): MergeResolver {
+	const timeoutMs = options.timeoutMs ?? 60_000;
+	const binary = options.binary ?? "codex";
+	const tmpdirRoot = options.tmpdirRoot ?? os.tmpdir();
+
+	return {
+		name: "codex",
+		async available(): Promise<boolean> {
+			try {
+				await execFn(binary, ["--version"]);
+				return true;
+			} catch {
+				return false;
+			}
+		},
+		async resolve(input: MergeInput): Promise<MergeOutput> {
+			const id = crypto.randomBytes(6).toString("hex");
+			const tempdir = path.join(tmpdirRoot, `ai-sync-merge-${process.pid}-${id}`);
+			await fs.mkdir(tempdir, { recursive: true });
+
+			const promptFile = path.join(tempdir, "prompt.txt");
+			const prompt = buildMergePrompt(
+				input.relativePath,
+				input.base,
+				input.local,
+				input.remote,
+				input.fileType,
+			);
+			try {
+				await fs.writeFile(promptFile, prompt, "utf-8");
+				// Preserve base/local/remote for postmortem
+				if (input.base !== null) {
+					await fs.writeFile(path.join(tempdir, "base.txt"), input.base, "utf-8");
+				}
+				await fs.writeFile(path.join(tempdir, "local.txt"), input.local, "utf-8");
+				await fs.writeFile(path.join(tempdir, "remote.txt"), input.remote, "utf-8");
+			} catch (err) {
+				throw new ResolverError(
+					"io-error",
+					`Failed to prepare tempdir ${tempdir}: ${(err as Error).message}`,
+					{ tempdir, cause: err },
+				);
+			}
+
+			const controller = new AbortController();
+			const timer = setTimeout(() => controller.abort(), timeoutMs);
+			let result: { stdout: string; stderr: string };
+			try {
+				result = await execFn(binary, ["exec", "--prompt-file", promptFile], {
+					signal: controller.signal,
+				});
+			} catch (err) {
+				const e = err as NodeJS.ErrnoException & { code?: string; killed?: boolean };
+				if (controller.signal.aborted || e.code === "ABORT_ERR" || e.name === "AbortError") {
+					throw new ResolverError(
+						"timeout",
+						`codex exceeded timeout of ${timeoutMs}ms (tempdir: ${tempdir})`,
+						{ tempdir, cause: err },
+					);
+				}
+				throw new ResolverError(
+					"non-zero-exit",
+					`codex exited non-zero: ${(err as Error).message} (tempdir: ${tempdir})`,
+					{ tempdir, cause: err },
+				);
+			} finally {
+				clearTimeout(timer);
+			}
+
+			const merged = result.stdout;
+			if (typeof merged !== "string" || merged.length === 0) {
+				throw new ResolverError(
+					"malformed-output",
+					`codex returned empty stdout (tempdir: ${tempdir})`,
+					{ tempdir },
+				);
+			}
+
+			// Success: cleanup tempdir.
+			try {
+				await fs.rm(tempdir, { recursive: true, force: true });
+			} catch {
+				// Best-effort cleanup; ignore failures.
+			}
+
+			return { mergedContent: merged };
+		},
+	};
+}

--- a/src/core/merge/adapters/index.ts
+++ b/src/core/merge/adapters/index.ts
@@ -1,19 +1,21 @@
 import type { MergeResolver } from "../resolver.js";
 import { createClaudeAdapter, type ExecFn } from "./claude-cli.js";
+import { createCodexAdapter } from "./codex-cli.js";
 
 export type AdapterName = "claude" | "codex" | "opencode";
 
 /**
  * Factory registry mapping adapter names to constructors.
- * codex and opencode adapters land in issues #25 and #26.
+ * opencode adapter lands in issue #26.
  */
 export function createAdapter(name: AdapterName, execFn?: ExecFn): MergeResolver {
 	switch (name) {
 		case "claude":
 			return createClaudeAdapter(execFn);
 		case "codex":
+			return createCodexAdapter(execFn);
 		case "opencode":
-			throw new Error(`Adapter "${name}" not implemented yet (tracked by issues #25/#26)`);
+			throw new Error(`Adapter "${name}" not implemented yet (tracked by issue #26)`);
 		default: {
 			const exhaustive: never = name;
 			throw new Error(`Unknown adapter: ${String(exhaustive)}`);

--- a/tests/core/merge/adapters/codex-cli.test.ts
+++ b/tests/core/merge/adapters/codex-cli.test.ts
@@ -1,0 +1,207 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ExecFn } from "../../../../src/core/merge/adapters/claude-cli.js";
+import { createCodexAdapter } from "../../../../src/core/merge/adapters/codex-cli.js";
+import { createAdapter } from "../../../../src/core/merge/adapters/index.js";
+import { ResolverError } from "../../../../src/core/merge/resolver.js";
+
+let tmpRoot: string;
+
+beforeEach(async () => {
+	tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "ai-sync-merge-test-"));
+});
+
+afterEach(async () => {
+	await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe("createCodexAdapter", () => {
+	describe("available()", () => {
+		it("returns true when codex --version succeeds", async () => {
+			const execFn: ExecFn = async (cmd, args) => {
+				expect(cmd).toBe("codex");
+				expect(args).toEqual(["--version"]);
+				return { stdout: "codex 0.1.0\n", stderr: "" };
+			};
+			const adapter = createCodexAdapter(execFn);
+			expect(adapter.name).toBe("codex");
+			expect(await adapter.available()).toBe(true);
+		});
+
+		it("returns false when codex --version throws", async () => {
+			const execFn: ExecFn = async () => {
+				throw new Error("ENOENT");
+			};
+			const adapter = createCodexAdapter(execFn);
+			expect(await adapter.available()).toBe(false);
+		});
+	});
+
+	describe("resolve()", () => {
+		it("returns stdout as mergedContent on success and invokes `codex exec --prompt-file <file>`", async () => {
+			const execFn: ExecFn = async (cmd, args) => {
+				expect(cmd).toBe("codex");
+				expect(args[0]).toBe("exec");
+				expect(args[1]).toBe("--prompt-file");
+				expect(args[2]).toContain("prompt.txt");
+				const promptContent = await fs.readFile(args[2], "utf-8");
+				expect(promptContent).toContain("CLAUDE.md");
+				expect(promptContent).toContain("local body");
+				expect(promptContent).toContain("remote body");
+				return { stdout: "merged body", stderr: "" };
+			};
+			const adapter = createCodexAdapter(execFn, { tmpdirRoot: tmpRoot });
+			const out = await adapter.resolve({
+				relativePath: "CLAUDE.md",
+				envName: "claude",
+				base: "base body",
+				local: "local body",
+				remote: "remote body",
+				fileType: { kind: "markdown" },
+			});
+			expect(out.mergedContent).toBe("merged body");
+		});
+
+		it("supports null base (new file on both sides)", async () => {
+			const execFn: ExecFn = async (_cmd, args) => {
+				const promptContent = await fs.readFile(args[2], "utf-8");
+				expect(promptContent).toContain("no common ancestor");
+				return { stdout: "merged", stderr: "" };
+			};
+			const adapter = createCodexAdapter(execFn, { tmpdirRoot: tmpRoot });
+			const out = await adapter.resolve({
+				relativePath: "new.md",
+				envName: "claude",
+				base: null,
+				local: "L",
+				remote: "R",
+				fileType: { kind: "markdown" },
+			});
+			expect(out.mergedContent).toBe("merged");
+		});
+
+		it("throws ResolverError with reason non-zero-exit on subprocess failure", async () => {
+			const execFn: ExecFn = async () => {
+				const err = new Error("exited with code 1") as NodeJS.ErrnoException;
+				err.code = "1";
+				throw err;
+			};
+			const adapter = createCodexAdapter(execFn, { tmpdirRoot: tmpRoot });
+			await expect(
+				adapter.resolve({
+					relativePath: "x.md",
+					envName: "claude",
+					base: null,
+					local: "a",
+					remote: "b",
+					fileType: { kind: "markdown" },
+				}),
+			).rejects.toMatchObject({
+				name: "ResolverError",
+				reason: "non-zero-exit",
+			});
+		});
+
+		it("throws ResolverError with reason timeout when signal aborts", async () => {
+			const execFn: ExecFn = async (_cmd, _args, opts) => {
+				return await new Promise((_resolve, reject) => {
+					opts?.signal?.addEventListener("abort", () => {
+						const err = new Error("aborted") as NodeJS.ErrnoException;
+						err.name = "AbortError";
+						err.code = "ABORT_ERR";
+						reject(err);
+					});
+				});
+			};
+			const adapter = createCodexAdapter(execFn, {
+				tmpdirRoot: tmpRoot,
+				timeoutMs: 25,
+			});
+			await expect(
+				adapter.resolve({
+					relativePath: "x.md",
+					envName: "claude",
+					base: null,
+					local: "a",
+					remote: "b",
+					fileType: { kind: "markdown" },
+				}),
+			).rejects.toMatchObject({
+				name: "ResolverError",
+				reason: "timeout",
+			});
+		});
+
+		it("throws ResolverError with reason malformed-output on empty stdout", async () => {
+			const execFn: ExecFn = async () => ({ stdout: "", stderr: "" });
+			const adapter = createCodexAdapter(execFn, { tmpdirRoot: tmpRoot });
+			await expect(
+				adapter.resolve({
+					relativePath: "x.md",
+					envName: "claude",
+					base: null,
+					local: "a",
+					remote: "b",
+					fileType: { kind: "markdown" },
+				}),
+			).rejects.toMatchObject({
+				name: "ResolverError",
+				reason: "malformed-output",
+			});
+		});
+
+		it("preserves tempdir on failure with path surfaced via error", async () => {
+			let capturedTempdir: string | undefined;
+			const execFn: ExecFn = async (_cmd, args) => {
+				capturedTempdir = path.dirname(args[2]);
+				throw new Error("boom");
+			};
+			const adapter = createCodexAdapter(execFn, { tmpdirRoot: tmpRoot });
+			try {
+				await adapter.resolve({
+					relativePath: "x.md",
+					envName: "claude",
+					base: null,
+					local: "a",
+					remote: "b",
+					fileType: { kind: "markdown" },
+				});
+				expect.fail("expected throw");
+			} catch (err) {
+				expect(err).toBeInstanceOf(ResolverError);
+				expect((err as ResolverError).tempdir).toBe(capturedTempdir);
+				const stat = await fs.stat(capturedTempdir as string);
+				expect(stat.isDirectory()).toBe(true);
+			}
+		});
+
+		it("cleans up tempdir on success", async () => {
+			let capturedTempdir: string | undefined;
+			const execFn: ExecFn = async (_cmd, args) => {
+				capturedTempdir = path.dirname(args[2]);
+				return { stdout: "merged", stderr: "" };
+			};
+			const adapter = createCodexAdapter(execFn, { tmpdirRoot: tmpRoot });
+			await adapter.resolve({
+				relativePath: "x.md",
+				envName: "claude",
+				base: null,
+				local: "a",
+				remote: "b",
+				fileType: { kind: "markdown" },
+			});
+			await expect(fs.stat(capturedTempdir as string)).rejects.toMatchObject({ code: "ENOENT" });
+		});
+	});
+
+	describe("adapter registry", () => {
+		it('createAdapter("codex") returns a codex MergeResolver', () => {
+			const adapter = createAdapter("codex");
+			expect(adapter.name).toBe("codex");
+			expect(typeof adapter.available).toBe("function");
+			expect(typeof adapter.resolve).toBe("function");
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Adds `createCodexAdapter(execFn, options)` in `src/core/merge/adapters/codex-cli.ts`, mirroring the claude-cli adapter shape.
- Probe via `codex --version`; resolve via `codex exec --prompt-file <file>`.
- 60s timeout via `AbortController`, tempdir under `os.tmpdir()/ai-sync-merge-<pid>-<random>/`, preserved on failure.
- Registers `codex` in the adapter factory (`src/core/merge/adapters/index.ts`).

Closes #25

## Test plan

- [x] `npm test -- tests/core/merge` — 41 passed
- [x] `npm run typecheck` — clean
- [x] `npx biome check` on new files — clean
- [x] AC: factory returns codex MergeResolver, args invocation verified, timeout/non-zero/malformed/preserved-tempdir all asserted

Acceptance criteria coverage:
- [x] `createCodexAdapter(execFn)` exported, name = "codex"
- [x] `available()` invokes `codex --version`
- [x] `resolve()` invokes `codex exec --prompt-file <file>` and returns stdout
- [x] 60s timeout via AbortController
- [x] Tempdir under `os.tmpdir()/ai-sync-merge-<pid>-<random>/` preserved on failure
- [x] Factory key `codex` registered
- [x] Tests pass

Generated with Claude Code.