### PR TITLE
feat(merge): opencode-cli adapter

### DIFF
--- a/src/core/merge/adapters/index.ts
+++ b/src/core/merge/adapters/index.ts
@@ -1,12 +1,12 @@
 import type { MergeResolver } from "../resolver.js";
 import { createClaudeAdapter, type ExecFn } from "./claude-cli.js";
 import { createCodexAdapter } from "./codex-cli.js";
+import { createOpencodeAdapter } from "./opencode-cli.js";
 
 export type AdapterName = "claude" | "codex" | "opencode";
 
 /**
  * Factory registry mapping adapter names to constructors.
- * opencode adapter lands in issue #26.
  */
 export function createAdapter(name: AdapterName, execFn?: ExecFn): MergeResolver {
 	switch (name) {
@@ -15,7 +15,7 @@ export function createAdapter(name: AdapterName, execFn?: ExecFn): MergeResolver
 		case "codex":
 			return createCodexAdapter(execFn);
 		case "opencode":
-			throw new Error(`Adapter "${name}" not implemented yet (tracked by issue #26)`);
+			return createOpencodeAdapter(execFn);
 		default: {
 			const exhaustive: never = name;
 			throw new Error(`Unknown adapter: ${String(exhaustive)}`);

--- a/src/core/merge/adapters/opencode-cli.ts
+++ b/src/core/merge/adapters/opencode-cli.ts
@@ -1,0 +1,124 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildMergePrompt } from "../prompts.js";
+import {
+	type MergeInput,
+	type MergeOutput,
+	type MergeResolver,
+	ResolverError,
+} from "../resolver.js";
+import { defaultExecFn, type ExecFn } from "./claude-cli.js";
+
+export interface OpencodeAdapterOptions {
+	/** Hard timeout in milliseconds for `resolve()`. Default 60_000. */
+	timeoutMs?: number;
+	/** Override the opencode binary name (default "opencode"). */
+	binary?: string;
+	/** Tempdir factory; defaults to os.tmpdir(). */
+	tmpdirRoot?: string;
+}
+
+/**
+ * Creates a MergeResolver backed by the `opencode` CLI.
+ *
+ * `available()` runs `opencode --version` via the injected execFn.
+ * `resolve()` writes the prompt to a tempdir, invokes
+ * `opencode run -p <file>`, and returns stdout as the merged
+ * content. A hard timeout is enforced via AbortController. On success the
+ * tempdir is cleaned up; on failure it is preserved and the path is
+ * surfaced via ResolverError.tempdir.
+ */
+export function createOpencodeAdapter(
+	execFn: ExecFn = defaultExecFn,
+	options: OpencodeAdapterOptions = {},
+): MergeResolver {
+	const timeoutMs = options.timeoutMs ?? 60_000;
+	const binary = options.binary ?? "opencode";
+	const tmpdirRoot = options.tmpdirRoot ?? os.tmpdir();
+
+	return {
+		name: "opencode",
+		async available(): Promise<boolean> {
+			try {
+				await execFn(binary, ["--version"]);
+				return true;
+			} catch {
+				return false;
+			}
+		},
+		async resolve(input: MergeInput): Promise<MergeOutput> {
+			const id = crypto.randomBytes(6).toString("hex");
+			const tempdir = path.join(tmpdirRoot, `ai-sync-merge-${process.pid}-${id}`);
+			await fs.mkdir(tempdir, { recursive: true });
+
+			const promptFile = path.join(tempdir, "prompt.txt");
+			const prompt = buildMergePrompt(
+				input.relativePath,
+				input.base,
+				input.local,
+				input.remote,
+				input.fileType,
+			);
+			try {
+				await fs.writeFile(promptFile, prompt, "utf-8");
+				// Preserve base/local/remote for postmortem
+				if (input.base !== null) {
+					await fs.writeFile(path.join(tempdir, "base.txt"), input.base, "utf-8");
+				}
+				await fs.writeFile(path.join(tempdir, "local.txt"), input.local, "utf-8");
+				await fs.writeFile(path.join(tempdir, "remote.txt"), input.remote, "utf-8");
+			} catch (err) {
+				throw new ResolverError(
+					"io-error",
+					`Failed to prepare tempdir ${tempdir}: ${(err as Error).message}`,
+					{ tempdir, cause: err },
+				);
+			}
+
+			const controller = new AbortController();
+			const timer = setTimeout(() => controller.abort(), timeoutMs);
+			let result: { stdout: string; stderr: string };
+			try {
+				result = await execFn(binary, ["run", "-p", promptFile], {
+					signal: controller.signal,
+				});
+			} catch (err) {
+				const e = err as NodeJS.ErrnoException & { code?: string; killed?: boolean };
+				if (controller.signal.aborted || e.code === "ABORT_ERR" || e.name === "AbortError") {
+					throw new ResolverError(
+						"timeout",
+						`opencode exceeded timeout of ${timeoutMs}ms (tempdir: ${tempdir})`,
+						{ tempdir, cause: err },
+					);
+				}
+				throw new ResolverError(
+					"non-zero-exit",
+					`opencode exited non-zero: ${(err as Error).message} (tempdir: ${tempdir})`,
+					{ tempdir, cause: err },
+				);
+			} finally {
+				clearTimeout(timer);
+			}
+
+			const merged = result.stdout;
+			if (typeof merged !== "string" || merged.length === 0) {
+				throw new ResolverError(
+					"malformed-output",
+					`opencode returned empty stdout (tempdir: ${tempdir})`,
+					{ tempdir },
+				);
+			}
+
+			// Success: cleanup tempdir.
+			try {
+				await fs.rm(tempdir, { recursive: true, force: true });
+			} catch {
+				// Best-effort cleanup; ignore failures.
+			}
+
+			return { mergedContent: merged };
+		},
+	};
+}

--- a/tests/core/merge/adapters/opencode-cli.test.ts
+++ b/tests/core/merge/adapters/opencode-cli.test.ts
@@ -1,0 +1,207 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ExecFn } from "../../../../src/core/merge/adapters/claude-cli.js";
+import { createAdapter } from "../../../../src/core/merge/adapters/index.js";
+import { createOpencodeAdapter } from "../../../../src/core/merge/adapters/opencode-cli.js";
+import { ResolverError } from "../../../../src/core/merge/resolver.js";
+
+let tmpRoot: string;
+
+beforeEach(async () => {
+	tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "ai-sync-merge-test-"));
+});
+
+afterEach(async () => {
+	await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe("createOpencodeAdapter", () => {
+	describe("available()", () => {
+		it("returns true when opencode --version succeeds", async () => {
+			const execFn: ExecFn = async (cmd, args) => {
+				expect(cmd).toBe("opencode");
+				expect(args).toEqual(["--version"]);
+				return { stdout: "opencode 0.1.0\n", stderr: "" };
+			};
+			const adapter = createOpencodeAdapter(execFn);
+			expect(adapter.name).toBe("opencode");
+			expect(await adapter.available()).toBe(true);
+		});
+
+		it("returns false when opencode --version throws", async () => {
+			const execFn: ExecFn = async () => {
+				throw new Error("ENOENT");
+			};
+			const adapter = createOpencodeAdapter(execFn);
+			expect(await adapter.available()).toBe(false);
+		});
+	});
+
+	describe("resolve()", () => {
+		it("returns stdout as mergedContent on success and invokes `opencode run -p <file>`", async () => {
+			const execFn: ExecFn = async (cmd, args) => {
+				expect(cmd).toBe("opencode");
+				expect(args[0]).toBe("run");
+				expect(args[1]).toBe("-p");
+				expect(args[2]).toContain("prompt.txt");
+				const promptContent = await fs.readFile(args[2], "utf-8");
+				expect(promptContent).toContain("CLAUDE.md");
+				expect(promptContent).toContain("local body");
+				expect(promptContent).toContain("remote body");
+				return { stdout: "merged body", stderr: "" };
+			};
+			const adapter = createOpencodeAdapter(execFn, { tmpdirRoot: tmpRoot });
+			const out = await adapter.resolve({
+				relativePath: "CLAUDE.md",
+				envName: "claude",
+				base: "base body",
+				local: "local body",
+				remote: "remote body",
+				fileType: { kind: "markdown" },
+			});
+			expect(out.mergedContent).toBe("merged body");
+		});
+
+		it("supports null base (new file on both sides)", async () => {
+			const execFn: ExecFn = async (_cmd, args) => {
+				const promptContent = await fs.readFile(args[2], "utf-8");
+				expect(promptContent).toContain("no common ancestor");
+				return { stdout: "merged", stderr: "" };
+			};
+			const adapter = createOpencodeAdapter(execFn, { tmpdirRoot: tmpRoot });
+			const out = await adapter.resolve({
+				relativePath: "new.md",
+				envName: "claude",
+				base: null,
+				local: "L",
+				remote: "R",
+				fileType: { kind: "markdown" },
+			});
+			expect(out.mergedContent).toBe("merged");
+		});
+
+		it("throws ResolverError with reason non-zero-exit on subprocess failure", async () => {
+			const execFn: ExecFn = async () => {
+				const err = new Error("exited with code 1") as NodeJS.ErrnoException;
+				err.code = "1";
+				throw err;
+			};
+			const adapter = createOpencodeAdapter(execFn, { tmpdirRoot: tmpRoot });
+			await expect(
+				adapter.resolve({
+					relativePath: "x.md",
+					envName: "claude",
+					base: null,
+					local: "a",
+					remote: "b",
+					fileType: { kind: "markdown" },
+				}),
+			).rejects.toMatchObject({
+				name: "ResolverError",
+				reason: "non-zero-exit",
+			});
+		});
+
+		it("throws ResolverError with reason timeout when signal aborts", async () => {
+			const execFn: ExecFn = async (_cmd, _args, opts) => {
+				return await new Promise((_resolve, reject) => {
+					opts?.signal?.addEventListener("abort", () => {
+						const err = new Error("aborted") as NodeJS.ErrnoException;
+						err.name = "AbortError";
+						err.code = "ABORT_ERR";
+						reject(err);
+					});
+				});
+			};
+			const adapter = createOpencodeAdapter(execFn, {
+				tmpdirRoot: tmpRoot,
+				timeoutMs: 25,
+			});
+			await expect(
+				adapter.resolve({
+					relativePath: "x.md",
+					envName: "claude",
+					base: null,
+					local: "a",
+					remote: "b",
+					fileType: { kind: "markdown" },
+				}),
+			).rejects.toMatchObject({
+				name: "ResolverError",
+				reason: "timeout",
+			});
+		});
+
+		it("throws ResolverError with reason malformed-output on empty stdout", async () => {
+			const execFn: ExecFn = async () => ({ stdout: "", stderr: "" });
+			const adapter = createOpencodeAdapter(execFn, { tmpdirRoot: tmpRoot });
+			await expect(
+				adapter.resolve({
+					relativePath: "x.md",
+					envName: "claude",
+					base: null,
+					local: "a",
+					remote: "b",
+					fileType: { kind: "markdown" },
+				}),
+			).rejects.toMatchObject({
+				name: "ResolverError",
+				reason: "malformed-output",
+			});
+		});
+
+		it("preserves tempdir on failure with path surfaced via error", async () => {
+			let capturedTempdir: string | undefined;
+			const execFn: ExecFn = async (_cmd, args) => {
+				capturedTempdir = path.dirname(args[2]);
+				throw new Error("boom");
+			};
+			const adapter = createOpencodeAdapter(execFn, { tmpdirRoot: tmpRoot });
+			try {
+				await adapter.resolve({
+					relativePath: "x.md",
+					envName: "claude",
+					base: null,
+					local: "a",
+					remote: "b",
+					fileType: { kind: "markdown" },
+				});
+				expect.fail("expected throw");
+			} catch (err) {
+				expect(err).toBeInstanceOf(ResolverError);
+				expect((err as ResolverError).tempdir).toBe(capturedTempdir);
+				const stat = await fs.stat(capturedTempdir as string);
+				expect(stat.isDirectory()).toBe(true);
+			}
+		});
+
+		it("cleans up tempdir on success", async () => {
+			let capturedTempdir: string | undefined;
+			const execFn: ExecFn = async (_cmd, args) => {
+				capturedTempdir = path.dirname(args[2]);
+				return { stdout: "merged", stderr: "" };
+			};
+			const adapter = createOpencodeAdapter(execFn, { tmpdirRoot: tmpRoot });
+			await adapter.resolve({
+				relativePath: "x.md",
+				envName: "claude",
+				base: null,
+				local: "a",
+				remote: "b",
+				fileType: { kind: "markdown" },
+			});
+			await expect(fs.stat(capturedTempdir as string)).rejects.toMatchObject({ code: "ENOENT" });
+		});
+	});
+
+	describe("adapter registry", () => {
+		it('createAdapter("opencode") returns an opencode MergeResolver', () => {
+			const adapter = createAdapter("opencode");
+			expect(adapter.name).toBe("opencode");
+			expect(typeof adapter.available).toBe("function");
+			expect(typeof adapter.resolve).toBe("function");
+		});
+	});
+});


### PR DESCRIPTION
Closes #26

Sibling-mirror of #24 (claude-cli) / #25 (codex-cli). Adds `createOpencodeAdapter(execFn, options)` that probes via `opencode --version` and resolves merges via `opencode run -p <prompt-file>`. 60s AbortController timeout, tempdir under `os.tmpdir()/ai-sync-merge-<pid>-<random>/` preserved on failure (path surfaced via `ResolverError.tempdir`), cleaned up on success. Registry entry added under key `opencode`.

## Test plan
- [x] `npm test -- tests/core/merge` — all 51 tests pass (9 new opencode tests)
- [x] `npm run typecheck` — clean
- [x] biome check on changed files — clean