### PR TITLE
feat(merge): per-file-type strategy dispatcher with parse-validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 				"commander": "^14.0.2",
 				"picocolors": "^1.1.1",
 				"simple-git": "^3.32.3",
+				"yaml": "^2.9.0",
 				"zod": "^4.3.6"
 			},
 			"bin": {
@@ -3584,6 +3585,21 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"commander": "^14.0.2",
 		"picocolors": "^1.1.1",
 		"simple-git": "^3.32.3",
+		"yaml": "^2.9.0",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/src/core/merge/index.ts
+++ b/src/core/merge/index.ts
@@ -1,7 +1,7 @@
-import * as path from "node:path";
 import type { MergeConfig } from "./config.js";
 import { type FileType, type MergeResolver, ResolverError } from "./resolver.js";
 import { type StagedEntry, stage } from "./staging.js";
+import { classify, mergeWithStrategy } from "./strategies.js";
 
 export type { ExecFn } from "./adapters/claude-cli.js";
 export { createClaudeAdapter, defaultExecFn } from "./adapters/claude-cli.js";
@@ -19,23 +19,20 @@ export type {
 export { ResolverError } from "./resolver.js";
 export type { StagedEntry, StageInput } from "./staging.js";
 export { ensureGitignoreEntry, listStaged, stage } from "./staging.js";
+export type {
+	StrategyName,
+	StrategyReason,
+	StrategyResult,
+} from "./strategies.js";
+export { classify, mergeWithStrategy } from "./strategies.js";
 
-/** Classify a file by its extension. Content-sniffing is left to #27. */
+/**
+ * Classify a file by its extension. Kept as a stable name for legacy callers;
+ * delegates to `classify()` from strategies.ts (issue #27) so there is one
+ * source of truth.
+ */
 export function classifyFile(relativePath: string): FileType {
-	const ext = path.extname(relativePath).toLowerCase();
-	switch (ext) {
-		case ".md":
-		case ".markdown":
-		case ".txt":
-			return { kind: "markdown" };
-		case ".json":
-			return { kind: "json" };
-		case ".yml":
-		case ".yaml":
-			return { kind: "yaml" };
-		default:
-			return { kind: "unknown", extension: ext };
-	}
+	return classify(relativePath);
 }
 
 export interface TryAiMergeInput {
@@ -78,25 +75,35 @@ export async function tryAiMerge(
 	if (!deps.config.enabled) {
 		return { kind: "fallback", reason: "disabled" };
 	}
-	const fileType = classifyFile(input.relativePath);
+	const fileType = classify(input.relativePath);
 	try {
-		const output = await deps.resolver.resolve({
-			relativePath: input.relativePath,
-			envName: input.envName,
-			base: input.base,
-			local: input.local,
-			remote: input.remote,
-			fileType,
-		});
+		const dispatch = await mergeWithStrategy(
+			{
+				relativePath: input.relativePath,
+				envName: input.envName,
+				base: input.base,
+				local: input.local,
+				remote: input.remote,
+				fileType,
+			},
+			deps.resolver,
+			deps.config,
+		);
+		if (!dispatch.ok) {
+			deps.warn?.(
+				`AI merge fell back to keep-local for ${input.envName}/${input.relativePath}: ${dispatch.reason}`,
+			);
+			return { kind: "fallback", reason: dispatch.reason };
+		}
 		if (deps.config.autoApply) {
-			return { kind: "applied", mergedContent: output.mergedContent };
+			return { kind: "applied", mergedContent: dispatch.mergedContent };
 		}
 		const entry = await stage(deps.syncRepoDir, {
 			envName: input.envName,
 			relativePath: input.relativePath,
-			mergedContent: output.mergedContent,
+			mergedContent: dispatch.mergedContent,
 			resolver: deps.resolver.name,
-			notes: output.notes,
+			notes: dispatch.notes,
 		});
 		return { kind: "staged", entry };
 	} catch (err) {

--- a/src/core/merge/strategies.ts
+++ b/src/core/merge/strategies.ts
@@ -1,0 +1,164 @@
+/**
+ * Per-file-type merge strategy dispatcher.
+ *
+ * Routes a MergeInput through a resolver based on its file type, then
+ * applies post-merge validation:
+ *   - markdown / ai-freeform → resolver output is returned verbatim
+ *   - json / ai-validated    → JSON.parse the merged content (throw → json-parse)
+ *   - yaml / ai-validated    → yaml.parse the merged content (throw → yaml-parse)
+ *   - unknown / keep-local   → short-circuit without calling the resolver
+ *
+ * Per-type overrides come from `config.perType`, a glob → strategy-name map.
+ * v1 glob support is intentionally minimal — only `*.ext` extension patterns
+ * and the catch-all `*` are matched. This is sufficient for the defaults in
+ * docs/specs/2026-05-22-ai-merge-resolver-design.md §4.5; richer globbing can
+ * be added once a real need shows up.
+ */
+
+import * as path from "node:path";
+import * as yaml from "yaml";
+import type { MergeConfig } from "./config.js";
+import type { FileType, MergeInput, MergeResolver } from "./resolver.js";
+
+export type StrategyName = "ai-freeform" | "ai-validated" | "keep-local";
+
+export type StrategyReason =
+	| "json-parse"
+	| "yaml-parse"
+	| "unsupported-type"
+	| "keep-local-override";
+
+export type StrategyResult =
+	| { ok: true; mergedContent: string; fileType: FileType; notes?: string }
+	| { ok: false; reason: StrategyReason; fileType: FileType };
+
+/**
+ * Classify a file by its extension. Content-sniffing for unextensioned files
+ * (e.g., `Makefile`) intentionally returns `unknown` with empty extension.
+ */
+export function classify(relativePath: string): FileType {
+	const ext = path.extname(relativePath).toLowerCase();
+	switch (ext) {
+		case ".md":
+		case ".markdown":
+		case ".txt":
+			return { kind: "markdown" };
+		case ".json":
+			return { kind: "json" };
+		case ".yml":
+		case ".yaml":
+			return { kind: "yaml" };
+		default:
+			return { kind: "unknown", extension: ext };
+	}
+}
+
+/**
+ * Match a relative path against a minimal glob.
+ *
+ * Supported forms:
+ *   - "*"            → matches anything
+ *   - "*.ext"        → matches basenames whose extension is `.ext`
+ *   - exact string   → matches a literal basename or full relative path
+ *
+ * Anything else falls back to a literal compare.
+ */
+function globMatch(pattern: string, relativePath: string): boolean {
+	if (pattern === "*") return true;
+	const base = path.basename(relativePath);
+	if (pattern.startsWith("*.")) {
+		const want = pattern.slice(1).toLowerCase(); // ".ext"
+		return path.extname(base).toLowerCase() === want;
+	}
+	return pattern === base || pattern === relativePath;
+}
+
+/**
+ * Determine the strategy for a path. The first matching `perType` entry
+ * (in declaration order) wins; a catch-all `*` matches last by convention.
+ *
+ * When no override matches, the default strategy is derived from the file
+ * type: markdown → ai-freeform; json/yaml → ai-validated; unknown → keep-local.
+ */
+function pickStrategy(
+	relativePath: string,
+	fileType: FileType,
+	perType: Record<string, string>,
+): StrategyName {
+	// Walk entries in insertion order, but defer "*" until last so a generic
+	// catch-all doesn't shadow a more specific later entry.
+	const entries = Object.entries(perType);
+	const specific = entries.filter(([p]) => p !== "*");
+	const wildcard = entries.find(([p]) => p === "*");
+	for (const [pattern, strat] of specific) {
+		if (globMatch(pattern, relativePath) && isStrategyName(strat)) {
+			return strat;
+		}
+	}
+	if (wildcard && isStrategyName(wildcard[1])) {
+		// Only honor `*` for unknown file types; typed files keep their
+		// type-appropriate default unless a specific glob said otherwise.
+		if (fileType.kind === "unknown") return wildcard[1];
+	}
+	switch (fileType.kind) {
+		case "markdown":
+			return "ai-freeform";
+		case "json":
+		case "yaml":
+			return "ai-validated";
+		default:
+			return "keep-local";
+	}
+}
+
+function isStrategyName(s: string): s is StrategyName {
+	return s === "ai-freeform" || s === "ai-validated" || s === "keep-local";
+}
+
+/**
+ * Dispatch a merge by file type, honoring per-type config overrides.
+ *
+ * Never throws: parse failures and unsupported types return `{ok: false}`
+ * so the orchestrator can cleanly fall back to keep-local.
+ */
+export async function mergeWithStrategy(
+	input: Omit<MergeInput, "fileType"> & { fileType?: FileType },
+	resolver: MergeResolver,
+	config: Pick<MergeConfig, "perType">,
+): Promise<StrategyResult> {
+	const fileType = input.fileType ?? classify(input.relativePath);
+	const strategy = pickStrategy(input.relativePath, fileType, config.perType);
+
+	if (strategy === "keep-local") {
+		return {
+			ok: false,
+			reason: fileType.kind === "unknown" ? "unsupported-type" : "keep-local-override",
+			fileType,
+		};
+	}
+
+	const output = await resolver.resolve({ ...input, fileType });
+	const merged = output.mergedContent;
+	const notes = output.notes;
+
+	if (strategy === "ai-freeform") {
+		return { ok: true, mergedContent: merged, fileType, notes };
+	}
+
+	// ai-validated → parse-validate per file type. Markdown under ai-validated
+	// is treated as JSON-shaped per spec §4.5 (rare but explicit).
+	if (fileType.kind === "yaml") {
+		try {
+			yaml.parse(merged);
+			return { ok: true, mergedContent: merged, fileType, notes };
+		} catch {
+			return { ok: false, reason: "yaml-parse", fileType };
+		}
+	}
+	try {
+		JSON.parse(merged);
+		return { ok: true, mergedContent: merged, fileType, notes };
+	} catch {
+		return { ok: false, reason: "json-parse", fileType };
+	}
+}

--- a/tests/core/merge/orchestrator.test.ts
+++ b/tests/core/merge/orchestrator.test.ts
@@ -115,6 +115,47 @@ describe("tryAiMerge()", () => {
 		expect(staged).toHaveLength(0);
 	});
 
+	it("routes through mergeWithStrategy and falls back when JSON parse fails", async () => {
+		const cfg = { ...defaultMergeConfig(), enabled: true };
+		const warnings: string[] = [];
+		const result = await tryAiMerge(
+			{
+				relativePath: "settings.json",
+				envName: "claude",
+				base: "{}",
+				local: "{}",
+				remote: "{}",
+			},
+			{
+				config: cfg,
+				resolver: stubResolver("{not json"),
+				syncRepoDir,
+				warn: (m) => warnings.push(m),
+			},
+		);
+		expect(result.kind).toBe("fallback");
+		expect(result.kind === "fallback" && result.reason).toBe("json-parse");
+		expect(warnings.some((w) => w.includes("json-parse"))).toBe(true);
+		// strategy fallback should NOT stage anything
+		const staged = await listStaged(syncRepoDir);
+		expect(staged).toHaveLength(0);
+	});
+
+	it("routes a markdown file through ai-freeform and stages verbatim", async () => {
+		const cfg = { ...defaultMergeConfig(), enabled: true };
+		const result = await tryAiMerge(
+			{
+				relativePath: "CLAUDE.md",
+				envName: "claude",
+				base: null,
+				local: "L",
+				remote: "R",
+			},
+			{ config: cfg, resolver: stubResolver("# merged\n"), syncRepoDir },
+		);
+		expect(result.kind).toBe("staged");
+	});
+
 	it("returns fallback when the resolver throws — never propagates", async () => {
 		const cfg = { ...defaultMergeConfig(), enabled: true };
 		const resolver: MergeResolver = {

--- a/tests/core/merge/strategies.test.ts
+++ b/tests/core/merge/strategies.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import { defaultMergeConfig } from "../../../src/core/merge/config.js";
+import type { MergeInput, MergeResolver } from "../../../src/core/merge/resolver.js";
+import { classify, mergeWithStrategy } from "../../../src/core/merge/strategies.js";
+
+function fakeResolver(merged: string): MergeResolver & { calls: number } {
+	const out = {
+		name: "fake",
+		calls: 0,
+		async available() {
+			return true;
+		},
+		async resolve() {
+			out.calls++;
+			return { mergedContent: merged };
+		},
+	};
+	return out;
+}
+
+const baseInput = (relativePath: string): Omit<MergeInput, "fileType"> => ({
+	relativePath,
+	envName: "claude",
+	base: "B",
+	local: "L",
+	remote: "R",
+});
+
+describe("classify()", () => {
+	it("matches the orchestrator's classifyFile()", () => {
+		expect(classify("a.md").kind).toBe("markdown");
+		expect(classify("a.json").kind).toBe("json");
+		expect(classify("a.yaml").kind).toBe("yaml");
+		expect(classify("Makefile").kind).toBe("unknown");
+	});
+});
+
+describe("mergeWithStrategy()", () => {
+	const cfg = defaultMergeConfig();
+
+	it("markdown passes resolver output through verbatim", async () => {
+		const r = fakeResolver("# merged content\n");
+		const result = await mergeWithStrategy(baseInput("CLAUDE.md"), r, cfg);
+		expect(r.calls).toBe(1);
+		expect(result.ok).toBe(true);
+		expect(result.ok && result.mergedContent).toBe("# merged content\n");
+		expect(result.fileType.kind).toBe("markdown");
+	});
+
+	it("valid JSON passes parse-validation", async () => {
+		const r = fakeResolver('{"a": 1, "b": [2, 3]}');
+		const result = await mergeWithStrategy(baseInput("settings.json"), r, cfg);
+		expect(result.ok).toBe(true);
+		expect(result.ok && result.mergedContent).toBe('{"a": 1, "b": [2, 3]}');
+	});
+
+	it("invalid JSON returns ok=false reason=json-parse", async () => {
+		const r = fakeResolver('{"a": 1,'); // truncated
+		const result = await mergeWithStrategy(baseInput("settings.json"), r, cfg);
+		expect(result.ok).toBe(false);
+		expect(!result.ok && result.reason).toBe("json-parse");
+	});
+
+	it("valid YAML passes parse-validation", async () => {
+		const r = fakeResolver("a: 1\nb:\n  - 2\n  - 3\n");
+		const result = await mergeWithStrategy(baseInput("config.yaml"), r, cfg);
+		expect(result.ok).toBe(true);
+		expect(result.fileType.kind).toBe("yaml");
+	});
+
+	it("invalid YAML returns ok=false reason=yaml-parse", async () => {
+		const r = fakeResolver("a: 1\n  b: : :\n\t- bad indent"); // tab+invalid
+		const result = await mergeWithStrategy(baseInput("config.yaml"), r, cfg);
+		expect(result.ok).toBe(false);
+		expect(!result.ok && result.reason).toBe("yaml-parse");
+	});
+
+	it("unknown extension returns ok=false reason=unsupported-type", async () => {
+		const r = fakeResolver("anything");
+		const result = await mergeWithStrategy(baseInput("Makefile"), r, cfg);
+		expect(r.calls).toBe(0);
+		expect(result.ok).toBe(false);
+		expect(!result.ok && result.reason).toBe("unsupported-type");
+	});
+
+	it("perType override forces keep-local on *.lock without calling resolver", async () => {
+		const r = fakeResolver("would have merged");
+		const result = await mergeWithStrategy(baseInput("package-lock.json"), r, {
+			perType: { "*.json": "keep-local" },
+		});
+		expect(r.calls).toBe(0);
+		expect(result.ok).toBe(false);
+		expect(!result.ok && result.reason).toBe("keep-local-override");
+	});
+
+	it("perType override: *.md → ai-validated treats markdown as JSON-shaped", async () => {
+		const r = fakeResolver("not json");
+		const result = await mergeWithStrategy(baseInput("note.md"), r, {
+			perType: { "*.md": "ai-validated" },
+		});
+		expect(r.calls).toBe(1);
+		expect(result.ok).toBe(false);
+		expect(!result.ok && result.reason).toBe("json-parse");
+	});
+
+	it("perType override: *.md → ai-validated with valid JSON content passes", async () => {
+		const r = fakeResolver('{"ok":true}');
+		const result = await mergeWithStrategy(baseInput("note.md"), r, {
+			perType: { "*.md": "ai-validated" },
+		});
+		expect(result.ok).toBe(true);
+	});
+
+	it("perType *.lock → keep-local short-circuits", async () => {
+		const r = fakeResolver("x");
+		const result = await mergeWithStrategy(baseInput("yarn.lock"), r, {
+			perType: { "*.lock": "keep-local", "*": "ai-freeform" },
+		});
+		expect(r.calls).toBe(0);
+		expect(result.ok).toBe(false);
+	});
+
+	it("does not propagate resolver exceptions — caller handles them", async () => {
+		const resolver: MergeResolver = {
+			name: "boom",
+			available: async () => true,
+			resolve: vi.fn().mockRejectedValue(new Error("nope")),
+		};
+		await expect(mergeWithStrategy(baseInput("a.md"), resolver, cfg)).rejects.toThrow("nope");
+	});
+});


### PR DESCRIPTION
## Summary
- Adds `src/core/merge/strategies.ts` with `mergeWithStrategy()` + `classify()`, routing merges by file type: markdown free-form, JSON/YAML AI-merged with post-parse validation, unknown -> keep-local.
- Honors `tools/merge-config.json` `perType` glob -> strategy overrides (v1 minimal globbing: `*.ext` + `*`).
- Wires dispatcher into `tryAiMerge` so JSON/YAML parse failures cleanly fall back to keep-local without staging.
- Adds `yaml@^2` dep.

Closes #27

## Test plan
- [x] `npm run typecheck`
- [x] `npm test -- tests/core/merge/strategies.test.ts tests/core/merge/orchestrator.test.ts` — 20/20 pass
- [x] `npm run test:coverage` — `strategies.ts` 87% statements / 100% functions (>=80% AC)
- [x] `npx biome check` on changed files clean
- [x] Pre-existing `tests/commands/link.test.ts` ENOTEMPTY flake reproduces on `main` — unrelated