### PR TITLE
feat(cli): ai-sync resolve (list/diff/accept/reject)

### DIFF
--- a/src/cli/commands/resolve.ts
+++ b/src/cli/commands/resolve.ts
@@ -1,0 +1,308 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { getEnvironmentById } from "../../core/environment.js";
+import {
+	acceptStaged,
+	getStagedContent,
+	listStaged,
+	rejectStaged,
+	type StagedEntry,
+} from "../../core/merge/staging.js";
+import { getSyncRepoDir } from "../../platform/paths.js";
+
+export interface ResolveOptions {
+	repoPath?: string;
+}
+
+export interface ResolveTargetOptions extends ResolveOptions {
+	all?: boolean;
+}
+
+/** Resolve the sync repo dir from options or fall back to default. */
+function resolveRepoPath(options: ResolveOptions): string {
+	return options.repoPath ?? getSyncRepoDir();
+}
+
+/** Try to read the live (current on-disk) target file, or null if missing. */
+async function readLiveTarget(targetPath: string): Promise<string | null> {
+	try {
+		return await fs.readFile(targetPath, "utf-8");
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+		throw err;
+	}
+}
+
+/**
+ * Resolves the absolute live target path for an entry:
+ * `<env.getConfigDir()>/<entry.relativePath>`. Returns null when the env is
+ * unknown.
+ */
+function resolveTargetPath(entry: StagedEntry): string | null {
+	const env = getEnvironmentById(entry.envName);
+	if (!env) return null;
+	return path.join(env.getConfigDir(), entry.relativePath);
+}
+
+/**
+ * Render a small textual table of staged entries.
+ */
+function renderTable(entries: StagedEntry[]): string {
+	const header = ["ENV", "PATH", "RESOLVER", "TIMESTAMP"];
+	const rows = entries.map((e) => [e.envName, e.relativePath, e.resolver, e.timestamp]);
+	const widths = header.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i].length)));
+	const pad = (cells: string[]) => cells.map((c, i) => c.padEnd(widths[i])).join("  ");
+	const lines = [pad(header), pad(widths.map((w) => "-".repeat(w)))];
+	for (const r of rows) lines.push(pad(r));
+	return lines.join("\n");
+}
+
+/**
+ * Produce a tiny unified-style diff between two strings.
+ * Not a full LCS — adequate to show the contents side-by-side under common
+ * "+ / -" markers so users can see what changed.
+ */
+function unifiedDiff(local: string, merged: string, relPath: string): string {
+	const a = local.split("\n");
+	const b = merged.split("\n");
+	const lines: string[] = [];
+	lines.push(`--- a/${relPath} (local)`);
+	lines.push(`+++ b/${relPath} (merged)`);
+	const max = Math.max(a.length, b.length);
+	for (let i = 0; i < max; i++) {
+		const la = a[i];
+		const lb = b[i];
+		if (la === lb) {
+			if (la !== undefined) lines.push(` ${la}`);
+		} else {
+			if (la !== undefined) lines.push(`-${la}`);
+			if (lb !== undefined) lines.push(`+${lb}`);
+		}
+	}
+	return lines.join("\n");
+}
+
+/** Find an entry by relativePath. */
+function findEntry(entries: StagedEntry[], relPath: string): StagedEntry | undefined {
+	return entries.find((e) => e.relativePath === relPath);
+}
+
+/** Print "no staged merges" message in yellow. */
+function printEmpty(): void {
+	console.log(pc.yellow("No staged merges."));
+}
+
+/* ---------- handlers ---------- */
+
+export async function handleResolveList(options: ResolveOptions): Promise<void> {
+	const syncRepoDir = resolveRepoPath(options);
+	const entries = await listStaged(syncRepoDir);
+	if (entries.length === 0) {
+		printEmpty();
+		return;
+	}
+	console.log(pc.cyan(`${entries.length} staged merge${entries.length === 1 ? "" : "s"}:`));
+	console.log(renderTable(entries));
+}
+
+export async function handleResolveDiff(
+	relpath: string | undefined,
+	options: ResolveOptions,
+): Promise<void> {
+	const syncRepoDir = resolveRepoPath(options);
+	const entries = await listStaged(syncRepoDir);
+	if (entries.length === 0) {
+		printEmpty();
+		return;
+	}
+	let entry: StagedEntry | undefined;
+	if (relpath) {
+		entry = findEntry(entries, relpath);
+		if (!entry) {
+			console.error(pc.red(`Error: no staged merge for "${relpath}".`));
+			console.error(pc.yellow("Available paths:"));
+			for (const e of entries) console.error(pc.yellow(`  ${e.relativePath}`));
+			process.exitCode = 1;
+			return;
+		}
+	} else if (entries.length === 1) {
+		entry = entries[0];
+	} else {
+		console.error(pc.red("Error: multiple staged merges. Specify a relpath."));
+		for (const e of entries) console.error(pc.yellow(`  ${e.relativePath}`));
+		process.exitCode = 1;
+		return;
+	}
+	const targetPath = resolveTargetPath(entry);
+	const live = targetPath ? ((await readLiveTarget(targetPath)) ?? "") : "";
+	const merged = await getStagedContent(syncRepoDir, entry.envName, entry.relativePath);
+	console.log(unifiedDiff(live, merged, entry.relativePath));
+}
+
+async function acceptOne(syncRepoDir: string, entry: StagedEntry): Promise<void> {
+	const targetPath = resolveTargetPath(entry);
+	if (!targetPath) {
+		throw new Error(`unknown environment "${entry.envName}" for ${entry.relativePath}`);
+	}
+	await acceptStaged(syncRepoDir, entry.envName, entry.relativePath, targetPath);
+	console.log(pc.green(`Accepted ${entry.envName}/${entry.relativePath} -> ${targetPath}`));
+}
+
+export async function handleResolveAccept(
+	relpath: string | undefined,
+	options: ResolveTargetOptions,
+): Promise<void> {
+	const syncRepoDir = resolveRepoPath(options);
+	const entries = await listStaged(syncRepoDir);
+	if (entries.length === 0) {
+		printEmpty();
+		return;
+	}
+	if (options.all) {
+		for (const e of [...entries]) {
+			try {
+				await acceptOne(syncRepoDir, e);
+			} catch (err) {
+				const m = err instanceof Error ? err.message : String(err);
+				console.error(pc.red(`Error accepting ${e.relativePath}: ${m}`));
+				process.exitCode = 1;
+			}
+		}
+		return;
+	}
+	if (!relpath) {
+		console.error(pc.red("Error: relpath required (or use --all)."));
+		process.exitCode = 1;
+		return;
+	}
+	const entry = findEntry(entries, relpath);
+	if (!entry) {
+		console.error(pc.red(`Error: no staged merge for "${relpath}".`));
+		process.exitCode = 1;
+		return;
+	}
+	try {
+		await acceptOne(syncRepoDir, entry);
+	} catch (err) {
+		const m = err instanceof Error ? err.message : String(err);
+		console.error(pc.red(`Error: ${m}`));
+		process.exitCode = 1;
+	}
+}
+
+async function rejectOne(syncRepoDir: string, entry: StagedEntry): Promise<void> {
+	await rejectStaged(syncRepoDir, entry.envName, entry.relativePath);
+	console.log(pc.green(`Rejected ${entry.envName}/${entry.relativePath}`));
+}
+
+export async function handleResolveReject(
+	relpath: string | undefined,
+	options: ResolveTargetOptions,
+): Promise<void> {
+	const syncRepoDir = resolveRepoPath(options);
+	const entries = await listStaged(syncRepoDir);
+	if (entries.length === 0) {
+		printEmpty();
+		return;
+	}
+	if (options.all) {
+		for (const e of [...entries]) {
+			try {
+				await rejectOne(syncRepoDir, e);
+			} catch (err) {
+				const m = err instanceof Error ? err.message : String(err);
+				console.error(pc.red(`Error rejecting ${e.relativePath}: ${m}`));
+				process.exitCode = 1;
+			}
+		}
+		return;
+	}
+	if (!relpath) {
+		console.error(pc.red("Error: relpath required (or use --all)."));
+		process.exitCode = 1;
+		return;
+	}
+	const entry = findEntry(entries, relpath);
+	if (!entry) {
+		console.error(pc.red(`Error: no staged merge for "${relpath}".`));
+		process.exitCode = 1;
+		return;
+	}
+	try {
+		await rejectOne(syncRepoDir, entry);
+	} catch (err) {
+		const m = err instanceof Error ? err.message : String(err);
+		console.error(pc.red(`Error: ${m}`));
+		process.exitCode = 1;
+	}
+}
+
+/**
+ * Registers the "resolve" subcommand group on the CLI program.
+ */
+export function registerResolveCommand(program: Command): void {
+	const resolve = program
+		.command("resolve")
+		.description("Manage staged AI merges in .ai-sync/pending/");
+
+	const repoOpt = (cmd: Command): Command =>
+		cmd.option("--repo-path <path>", "Custom sync repo path", getSyncRepoDir());
+
+	repoOpt(resolve.command("list").description("List pending staged merges")).action(
+		async (opts: ResolveOptions) => {
+			try {
+				await handleResolveList(opts);
+			} catch (err) {
+				const m = err instanceof Error ? err.message : String(err);
+				console.error(pc.red(`Error: ${m}`));
+				process.exitCode = 1;
+			}
+		},
+	);
+
+	repoOpt(
+		resolve
+			.command("diff [relpath]")
+			.description("Show unified diff between local and staged merged file"),
+	).action(async (relpath: string | undefined, opts: ResolveOptions) => {
+		try {
+			await handleResolveDiff(relpath, opts);
+		} catch (err) {
+			const m = err instanceof Error ? err.message : String(err);
+			console.error(pc.red(`Error: ${m}`));
+			process.exitCode = 1;
+		}
+	});
+
+	repoOpt(
+		resolve
+			.command("accept [relpath]")
+			.description("Apply a staged merge to the live target")
+			.option("--all", "Accept every staged entry", false),
+	).action(async (relpath: string | undefined, opts: ResolveTargetOptions) => {
+		try {
+			await handleResolveAccept(relpath, opts);
+		} catch (err) {
+			const m = err instanceof Error ? err.message : String(err);
+			console.error(pc.red(`Error: ${m}`));
+			process.exitCode = 1;
+		}
+	});
+
+	repoOpt(
+		resolve
+			.command("reject [relpath]")
+			.description("Discard a staged merge")
+			.option("--all", "Reject every staged entry", false),
+	).action(async (relpath: string | undefined, opts: ResolveTargetOptions) => {
+		try {
+			await handleResolveReject(relpath, opts);
+		} catch (err) {
+			const m = err instanceof Error ? err.message : String(err);
+			console.error(pc.red(`Error: ${m}`));
+			process.exitCode = 1;
+		}
+	});
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,7 @@ import { registerLinkCommand } from "./commands/link.js";
 import { registerMigrateCommand } from "./commands/migrate.js";
 import { registerPullCommand } from "./commands/pull.js";
 import { registerPushCommand } from "./commands/push.js";
+import { registerResolveCommand } from "./commands/resolve.js";
 import { registerStatusCommand } from "./commands/status.js";
 import { registerUpdateCommand } from "./commands/update.js";
 
@@ -72,6 +73,7 @@ registerEnvCommand(program);
 registerLinkCommand(program);
 registerMigrateCommand(program);
 registerFragmentCommand(program);
+registerResolveCommand(program);
 
 export { program };
 

--- a/src/core/merge/index.ts
+++ b/src/core/merge/index.ts
@@ -17,8 +17,17 @@ export type {
 	MergeResolver,
 } from "./resolver.js";
 export { ResolverError } from "./resolver.js";
-export type { StagedEntry, StageInput } from "./staging.js";
-export { ensureGitignoreEntry, listStaged, stage } from "./staging.js";
+export type { AcceptResult, StagedEntry, StageInput } from "./staging.js";
+export {
+	acceptStaged,
+	ensureGitignoreEntry,
+	getStagedContent,
+	listStaged,
+	rejectStaged,
+	removeFromManifest,
+	stage,
+	stagedFilePath,
+} from "./staging.js";
 export type {
 	StrategyName,
 	StrategyReason,

--- a/src/core/merge/staging.ts
+++ b/src/core/merge/staging.ts
@@ -107,3 +107,83 @@ export async function listStaged(syncRepoDir: string): Promise<StagedEntry[]> {
 	const manifest = await readManifest(syncRepoDir);
 	return manifest.entries;
 }
+
+/**
+ * Returns the absolute path to a staged file inside `.ai-sync/pending/`.
+ */
+export function stagedFilePath(syncRepoDir: string, envName: string, relativePath: string): string {
+	return path.join(pendingDir(syncRepoDir), envName, relativePath);
+}
+
+/**
+ * Reads the staged (merged) file content for the given (env, relPath) pair.
+ * Throws if the file is missing.
+ */
+export async function getStagedContent(
+	syncRepoDir: string,
+	envName: string,
+	relativePath: string,
+): Promise<string> {
+	return fs.readFile(stagedFilePath(syncRepoDir, envName, relativePath), "utf-8");
+}
+
+/**
+ * Removes the entry for (envName, relativePath) from the manifest.
+ * Returns true if an entry was removed, false otherwise.
+ */
+export async function removeFromManifest(
+	syncRepoDir: string,
+	envName: string,
+	relativePath: string,
+): Promise<boolean> {
+	const manifest = await readManifest(syncRepoDir);
+	const idx = manifest.entries.findIndex(
+		(e) => e.envName === envName && e.relativePath === relativePath,
+	);
+	if (idx < 0) return false;
+	manifest.entries.splice(idx, 1);
+	await writeManifest(syncRepoDir, manifest);
+	return true;
+}
+
+export interface AcceptResult {
+	stagedPath: string;
+	targetPath: string;
+	content: string;
+}
+
+/**
+ * Accepts a staged merge by copying the staged file's content to `targetPath`,
+ * deleting the staged file, and removing the manifest entry.
+ *
+ * `targetPath` is resolved by the caller (typically `<env.getConfigDir()>/<relPath>`)
+ * so this function stays independent of environment lookup.
+ */
+export async function acceptStaged(
+	syncRepoDir: string,
+	envName: string,
+	relativePath: string,
+	targetPath: string,
+): Promise<AcceptResult> {
+	const stagedPath = stagedFilePath(syncRepoDir, envName, relativePath);
+	const content = await fs.readFile(stagedPath, "utf-8");
+	await fs.mkdir(path.dirname(targetPath), { recursive: true });
+	await fs.writeFile(targetPath, content, "utf-8");
+	await fs.rm(stagedPath, { force: true });
+	await removeFromManifest(syncRepoDir, envName, relativePath);
+	return { stagedPath, targetPath, content };
+}
+
+/**
+ * Rejects a staged merge by deleting the staged file and removing the manifest
+ * entry. The live target is left untouched.
+ */
+export async function rejectStaged(
+	syncRepoDir: string,
+	envName: string,
+	relativePath: string,
+): Promise<void> {
+	const stagedPath = stagedFilePath(syncRepoDir, envName, relativePath);
+	await fs.rm(stagedPath, { force: true });
+	await removeFromManifest(syncRepoDir, envName, relativePath);
+}

--- a/tests/cli/commands/resolve.test.ts
+++ b/tests/cli/commands/resolve.test.ts
@@ -1,0 +1,288 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	handleResolveAccept,
+	handleResolveDiff,
+	handleResolveList,
+	handleResolveReject,
+} from "../../../src/cli/commands/resolve.js";
+import { stage } from "../../../src/core/merge/staging.js";
+
+let baseDir: string;
+let syncRepoDir: string;
+let homeDir: string;
+let claudeDir: string;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+let originalHome: string | undefined;
+
+beforeEach(async () => {
+	baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "ai-sync-resolve-test-"));
+	syncRepoDir = path.join(baseDir, "sync-repo");
+	homeDir = path.join(baseDir, "home");
+	claudeDir = path.join(homeDir, ".claude");
+	await fs.mkdir(syncRepoDir, { recursive: true });
+	await fs.mkdir(claudeDir, { recursive: true });
+	originalHome = process.env.HOME;
+	process.env.HOME = homeDir;
+	logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+	errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	process.exitCode = 0;
+});
+
+afterEach(async () => {
+	logSpy.mockRestore();
+	errSpy.mockRestore();
+	if (originalHome === undefined) delete process.env.HOME;
+	else process.env.HOME = originalHome;
+	await fs.rm(baseDir, { recursive: true, force: true });
+	process.exitCode = 0;
+});
+
+function logged(): string {
+	return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+}
+function erred(): string {
+	return errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+}
+
+describe("handleResolveList", () => {
+	it("prints 'No staged merges.' when manifest is empty", async () => {
+		await handleResolveList({ repoPath: syncRepoDir });
+		expect(logged()).toMatch(/No staged merges/);
+	});
+
+	it("renders a row for each manifest entry", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "CLAUDE.md",
+			mergedContent: "merged a",
+			resolver: "claude",
+		});
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "agents/foo.md",
+			mergedContent: "merged b",
+			resolver: "claude",
+		});
+		await handleResolveList({ repoPath: syncRepoDir });
+		const out = logged();
+		expect(out).toContain("CLAUDE.md");
+		expect(out).toContain("agents/foo.md");
+		expect(out).toContain("claude");
+	});
+});
+
+describe("handleResolveDiff", () => {
+	it("prints a diff between live file and staged content", async () => {
+		await fs.writeFile(path.join(claudeDir, "CLAUDE.md"), "alpha\nshared\n", "utf-8");
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "CLAUDE.md",
+			mergedContent: "beta\nshared\n",
+			resolver: "claude",
+		});
+		await handleResolveDiff("CLAUDE.md", { repoPath: syncRepoDir });
+		const out = logged();
+		expect(out).toContain("-alpha");
+		expect(out).toContain("+beta");
+		expect(out).toContain(" shared");
+	});
+
+	it("defaults to the sole entry when relpath is omitted", async () => {
+		await fs.writeFile(path.join(claudeDir, "CLAUDE.md"), "old", "utf-8");
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "CLAUDE.md",
+			mergedContent: "new",
+			resolver: "claude",
+		});
+		await handleResolveDiff(undefined, { repoPath: syncRepoDir });
+		expect(logged()).toContain("CLAUDE.md");
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("errors with exit code 1 when relpath is ambiguous", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "a.md",
+			mergedContent: "A",
+			resolver: "claude",
+		});
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "b.md",
+			mergedContent: "B",
+			resolver: "claude",
+		});
+		await handleResolveDiff(undefined, { repoPath: syncRepoDir });
+		expect(process.exitCode).toBe(1);
+		expect(erred()).toMatch(/multiple staged merges/i);
+	});
+
+	it("errors with exit code 1 when relpath is unknown", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "a.md",
+			mergedContent: "A",
+			resolver: "claude",
+		});
+		await handleResolveDiff("nope.md", { repoPath: syncRepoDir });
+		expect(process.exitCode).toBe(1);
+		expect(erred()).toMatch(/no staged merge for/i);
+	});
+});
+
+describe("handleResolveAccept", () => {
+	it("copies staged file into live target and removes manifest entry", async () => {
+		await fs.writeFile(path.join(claudeDir, "CLAUDE.md"), "old", "utf-8");
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "CLAUDE.md",
+			mergedContent: "merged!",
+			resolver: "claude",
+		});
+		await handleResolveAccept("CLAUDE.md", { repoPath: syncRepoDir });
+		expect(process.exitCode).toBe(0);
+		const live = await fs.readFile(path.join(claudeDir, "CLAUDE.md"), "utf-8");
+		expect(live).toBe("merged!");
+		const manifestRaw = await fs.readFile(
+			path.join(syncRepoDir, ".ai-sync", "pending", "manifest.json"),
+			"utf-8",
+		);
+		expect(JSON.parse(manifestRaw).entries).toHaveLength(0);
+		const staged = path.join(syncRepoDir, ".ai-sync", "pending", "claude", "CLAUDE.md");
+		await expect(fs.access(staged)).rejects.toThrow();
+	});
+
+	it("creates target subdir when relpath includes a directory", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "agents/foo.md",
+			mergedContent: "agent merged",
+			resolver: "claude",
+		});
+		await handleResolveAccept("agents/foo.md", { repoPath: syncRepoDir });
+		const live = await fs.readFile(path.join(claudeDir, "agents", "foo.md"), "utf-8");
+		expect(live).toBe("agent merged");
+	});
+
+	it("--all accepts every staged entry", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "a.md",
+			mergedContent: "A",
+			resolver: "claude",
+		});
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "b.md",
+			mergedContent: "B",
+			resolver: "claude",
+		});
+		await handleResolveAccept(undefined, { repoPath: syncRepoDir, all: true });
+		expect(await fs.readFile(path.join(claudeDir, "a.md"), "utf-8")).toBe("A");
+		expect(await fs.readFile(path.join(claudeDir, "b.md"), "utf-8")).toBe("B");
+		const manifestRaw = await fs.readFile(
+			path.join(syncRepoDir, ".ai-sync", "pending", "manifest.json"),
+			"utf-8",
+		);
+		expect(JSON.parse(manifestRaw).entries).toHaveLength(0);
+	});
+
+	it("errors with exit code 1 when relpath is missing", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "a.md",
+			mergedContent: "A",
+			resolver: "claude",
+		});
+		await handleResolveAccept(undefined, { repoPath: syncRepoDir });
+		expect(process.exitCode).toBe(1);
+		expect(erred()).toMatch(/required/i);
+	});
+
+	it("errors with exit code 1 for unknown relpath", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "a.md",
+			mergedContent: "A",
+			resolver: "claude",
+		});
+		await handleResolveAccept("nope.md", { repoPath: syncRepoDir });
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("prints empty message when manifest has no entries", async () => {
+		await handleResolveAccept("anything", { repoPath: syncRepoDir });
+		expect(logged()).toMatch(/No staged merges/);
+	});
+});
+
+describe("handleResolveReject", () => {
+	it("deletes staged file and removes manifest entry; live file untouched", async () => {
+		await fs.writeFile(path.join(claudeDir, "CLAUDE.md"), "untouched", "utf-8");
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "CLAUDE.md",
+			mergedContent: "rejected merge",
+			resolver: "claude",
+		});
+		await handleResolveReject("CLAUDE.md", { repoPath: syncRepoDir });
+		expect(process.exitCode).toBe(0);
+		const live = await fs.readFile(path.join(claudeDir, "CLAUDE.md"), "utf-8");
+		expect(live).toBe("untouched");
+		const staged = path.join(syncRepoDir, ".ai-sync", "pending", "claude", "CLAUDE.md");
+		await expect(fs.access(staged)).rejects.toThrow();
+		const manifestRaw = await fs.readFile(
+			path.join(syncRepoDir, ".ai-sync", "pending", "manifest.json"),
+			"utf-8",
+		);
+		expect(JSON.parse(manifestRaw).entries).toHaveLength(0);
+	});
+
+	it("--all rejects every staged entry", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "a.md",
+			mergedContent: "A",
+			resolver: "claude",
+		});
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "b.md",
+			mergedContent: "B",
+			resolver: "claude",
+		});
+		await handleResolveReject(undefined, { repoPath: syncRepoDir, all: true });
+		const manifestRaw = await fs.readFile(
+			path.join(syncRepoDir, ".ai-sync", "pending", "manifest.json"),
+			"utf-8",
+		);
+		expect(JSON.parse(manifestRaw).entries).toHaveLength(0);
+	});
+
+	it("errors with exit code 1 when relpath is missing", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "a.md",
+			mergedContent: "A",
+			resolver: "claude",
+		});
+		await handleResolveReject(undefined, { repoPath: syncRepoDir });
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("errors for unknown relpath", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "a.md",
+			mergedContent: "A",
+			resolver: "claude",
+		});
+		await handleResolveReject("nope.md", { repoPath: syncRepoDir });
+		expect(process.exitCode).toBe(1);
+	});
+});

--- a/tests/core/merge/staging.test.ts
+++ b/tests/core/merge/staging.test.ts
@@ -2,7 +2,16 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { ensureGitignoreEntry, listStaged, stage } from "../../../src/core/merge/staging.js";
+import {
+	acceptStaged,
+	ensureGitignoreEntry,
+	getStagedContent,
+	listStaged,
+	rejectStaged,
+	removeFromManifest,
+	stage,
+	stagedFilePath,
+} from "../../../src/core/merge/staging.js";
 
 let syncRepoDir: string;
 
@@ -141,5 +150,100 @@ describe("ensureGitignoreEntry()", () => {
 		});
 		const contents = await fs.readFile(path.join(syncRepoDir, ".gitignore"), "utf-8");
 		expect(contents).toContain(".ai-sync/pending/");
+	});
+});
+
+describe("getStagedContent()", () => {
+	it("returns the merged content for a staged entry", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "CLAUDE.md",
+			mergedContent: "hello merged",
+			resolver: "claude",
+		});
+		const out = await getStagedContent(syncRepoDir, "claude", "CLAUDE.md");
+		expect(out).toBe("hello merged");
+	});
+
+	it("throws when staged file is missing", async () => {
+		await expect(getStagedContent(syncRepoDir, "claude", "missing.md")).rejects.toThrow();
+	});
+});
+
+describe("stagedFilePath()", () => {
+	it("composes the path under .ai-sync/pending/<env>/<rel>", () => {
+		const p = stagedFilePath(syncRepoDir, "claude", "agents/foo.md");
+		expect(p).toBe(path.join(syncRepoDir, ".ai-sync", "pending", "claude", "agents", "foo.md"));
+	});
+});
+
+describe("removeFromManifest()", () => {
+	it("removes a matching entry and returns true", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "a.md",
+			mergedContent: "A",
+			resolver: "claude",
+		});
+		const removed = await removeFromManifest(syncRepoDir, "claude", "a.md");
+		expect(removed).toBe(true);
+		expect(await listStaged(syncRepoDir)).toEqual([]);
+	});
+
+	it("returns false when no entry matches", async () => {
+		const removed = await removeFromManifest(syncRepoDir, "claude", "none.md");
+		expect(removed).toBe(false);
+	});
+});
+
+describe("acceptStaged()", () => {
+	it("copies staged content to targetPath, deletes staged file, removes entry", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "CLAUDE.md",
+			mergedContent: "final content",
+			resolver: "claude",
+		});
+		const targetPath = path.join(syncRepoDir, "live", "CLAUDE.md");
+		const result = await acceptStaged(syncRepoDir, "claude", "CLAUDE.md", targetPath);
+		expect(result.content).toBe("final content");
+		expect(result.targetPath).toBe(targetPath);
+		expect(await fs.readFile(targetPath, "utf-8")).toBe("final content");
+		await expect(
+			fs.access(path.join(syncRepoDir, ".ai-sync", "pending", "claude", "CLAUDE.md")),
+		).rejects.toThrow();
+		expect(await listStaged(syncRepoDir)).toEqual([]);
+	});
+
+	it("creates intermediate target directories", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "agents/foo.md",
+			mergedContent: "f",
+			resolver: "claude",
+		});
+		const targetPath = path.join(syncRepoDir, "live", "agents", "foo.md");
+		await acceptStaged(syncRepoDir, "claude", "agents/foo.md", targetPath);
+		expect(await fs.readFile(targetPath, "utf-8")).toBe("f");
+	});
+});
+
+describe("rejectStaged()", () => {
+	it("deletes staged file and removes manifest entry", async () => {
+		await stage(syncRepoDir, {
+			envName: "claude",
+			relativePath: "CLAUDE.md",
+			mergedContent: "drop me",
+			resolver: "claude",
+		});
+		await rejectStaged(syncRepoDir, "claude", "CLAUDE.md");
+		await expect(
+			fs.access(path.join(syncRepoDir, ".ai-sync", "pending", "claude", "CLAUDE.md")),
+		).rejects.toThrow();
+		expect(await listStaged(syncRepoDir)).toEqual([]);
+	});
+
+	it("is a no-op when nothing is staged", async () => {
+		await expect(rejectStaged(syncRepoDir, "claude", "missing.md")).resolves.toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Summary
- Adds `ai-sync resolve` subcommand group with `list`, `diff`, `accept`, `reject` to manage staged AI merges from `.ai-sync/pending/`.
- `accept`/`reject` support `--all` for bulk operations; both remove the manifest entry; `accept` copies merged content into the live target (`env.getConfigDir()/<relPath>`).
- Extends `src/core/merge/staging.ts` with `getStagedContent`, `acceptStaged`, `rejectStaged`, `removeFromManifest`, `stagedFilePath`.

Closes #28

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npx biome check` on changed files — clean
- [x] `npx vitest run tests/cli/commands/resolve.test.ts tests/core/merge/staging.test.ts` — 35/35 pass
- [ ] Manual: `node dist/cli.js resolve list` after build (operator)

Two pre-existing test failures in `tests/commands/link.test.ts` (ENOTEMPTY in plugins/cache cleanup) are unrelated to this change and reproduce on origin/main.