### PR TITLE
feat(cli): ai-sync status drift report

### DIFF
--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -1,12 +1,16 @@
 import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
 import type { Command } from "commander";
 import pc from "picocolors";
+import { classifyDrift, type DriftReport } from "../../core/drift.js";
 import { getEnabledEnvironmentInstances } from "../../core/env-config.js";
+import type { Environment } from "../../core/environment.js";
 import { verifyTool } from "../../core/provisioner.js";
 import type { SyncStatusResult } from "../../core/sync-engine.js";
 import { syncStatus } from "../../core/sync-engine.js";
 import { ToolManifestSchema } from "../../core/tool-manifest.js";
+import { fetchRemote, hasRemote } from "../../git/repo.js";
 import { getClaudeDir, getSyncRepoDir } from "../../platform/paths.js";
 import { printFileChanges } from "../format.js";
 
@@ -18,6 +22,10 @@ export interface StatusOptions {
 	claudeDir?: string;
 	env?: string;
 	verbose?: boolean;
+	/** Override the environment list (testing). */
+	environments?: Environment[];
+	/** Override the home dir used for path-rewrite normalization (testing). */
+	homeDir?: string;
 }
 
 /**
@@ -25,7 +33,7 @@ export interface StatusOptions {
  * Delegates to syncStatus from the sync engine.
  */
 export async function handleStatus(options: StatusOptions): Promise<SyncStatusResult> {
-	const environments = getEnabledEnvironmentInstances();
+	const environments = options.environments ?? getEnabledEnvironmentInstances();
 	return syncStatus({
 		claudeDir: options.claudeDir ?? getClaudeDir(),
 		syncRepoDir: options.repoPath ?? getSyncRepoDir(),
@@ -33,6 +41,108 @@ export async function handleStatus(options: StatusOptions): Promise<SyncStatusRe
 		filterEnv: options.env,
 		verbose: options.verbose,
 	});
+}
+
+/**
+ * Computes the drift report for every enabled environment.
+ *
+ * Fetches the remote (when configured) so the report reflects up-to-date
+ * remote state without modifying the working tree.
+ */
+export async function handleStatusDrift(options: StatusOptions): Promise<DriftReport[]> {
+	const syncRepoDir = options.repoPath ?? getSyncRepoDir();
+	const homeDir = options.homeDir ?? os.homedir();
+	let environments: Environment[];
+	if (options.environments) {
+		environments = options.environments;
+	} else if (options.claudeDir) {
+		// Legacy v1 single-env mode: build a synthetic claude env pointed at
+		// the explicit --claude-dir so the drift report doesn't accidentally
+		// scan the operator's real home directory during tests.
+		environments = [makeSyntheticClaudeEnv(options.claudeDir)];
+	} else {
+		environments = getEnabledEnvironmentInstances();
+	}
+	if (options.env) {
+		environments = environments.filter((e) => e.id === options.env);
+	}
+	try {
+		if (await hasRemote(syncRepoDir)) {
+			await fetchRemote(syncRepoDir);
+		}
+	} catch {
+		// Network or no-remote — drift will use HEAD as remote fallback.
+	}
+	return classifyDrift(environments, syncRepoDir, homeDir);
+}
+
+/**
+ * Builds an Environment that points at an explicit claudeDir. Used when the
+ * CLI is invoked with `--claude-dir` (legacy v1 mode) so drift classification
+ * stays scoped to the directory the operator named.
+ */
+function makeSyntheticClaudeEnv(claudeDir: string): Environment {
+	return {
+		id: "claude",
+		displayName: "Claude Code",
+		getConfigDir: () => claudeDir,
+		getSyncTargets: () => [
+			"settings.json",
+			"CLAUDE.md",
+			"agents/",
+			"commands/",
+			"hooks/",
+			"get-shit-done/",
+			"package.json",
+			"gsd-file-manifest.json",
+			"skills/",
+			"rules/",
+			"keybindings.json",
+		],
+		getPluginSyncPatterns: () => [],
+		getIgnorePatterns: () => [],
+		getPathRewriteTargets: () => ["settings.json"],
+		getSkillsSubdir: () => "commands",
+	};
+}
+
+/**
+ * Renders the drift report to stdout using picocolors. When `verbose` is true
+ * the filenames in each non-empty bucket are listed beneath the counts.
+ */
+export function printDriftReport(reports: DriftReport[], verbose: boolean): void {
+	if (reports.length === 0) {
+		console.log(pc.dim("No environments enabled."));
+		return;
+	}
+	for (const r of reports) {
+		const lo = r.localOnly.length;
+		const ro = r.remoteOnly.length;
+		const bc = r.bothChanged.length;
+		const sp = r.stagedPending.length;
+		console.log(
+			pc.cyan(`Env ${r.envName}:`) +
+				` local-only=${lo} remote-only=${ro} both-changed=${bc} staged-pending=${sp}`,
+		);
+		if (verbose) {
+			if (lo > 0) {
+				console.log(pc.dim("  local-only:"));
+				for (const f of r.localOnly) console.log(pc.dim(`    ${f}`));
+			}
+			if (ro > 0) {
+				console.log(pc.dim("  remote-only:"));
+				for (const f of r.remoteOnly) console.log(pc.dim(`    ${f}`));
+			}
+			if (bc > 0) {
+				console.log(pc.yellow("  both-changed:"));
+				for (const f of r.bothChanged) console.log(pc.yellow(`    ${f}`));
+			}
+			if (sp > 0) {
+				console.log(pc.dim("  staged-pending:"));
+				for (const f of r.stagedPending) console.log(pc.dim(`    ${f}`));
+			}
+		}
+	}
 }
 
 /**
@@ -52,6 +162,23 @@ export function registerStatusCommand(program: Command): void {
 
 				if (!result.hasRemote) {
 					console.log(pc.yellow("No remote configured"));
+				}
+
+				// Drift report (per env) — runs before legacy sections so the
+				// new structured output is the headline.
+				try {
+					const drift = await handleStatusDrift(opts);
+					printDriftReport(drift, !!opts.verbose);
+				} catch (driftErr) {
+					if (opts.verbose) {
+						console.error(
+							pc.yellow(
+								`  [verbose] drift report skipped: ${
+									driftErr instanceof Error ? driftErr.message : String(driftErr)
+								}`,
+							),
+						);
+					}
 				}
 
 				if (opts.verbose) {

--- a/src/core/drift.ts
+++ b/src/core/drift.ts
@@ -1,0 +1,180 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { simpleGit } from "simple-git";
+import { makeAllowlistFn, needsPathRewrite } from "./env-helpers.js";
+import type { Environment } from "./environment.js";
+import { listStaged } from "./merge/staging.js";
+import { detectRepoVersion } from "./migration.js";
+import { rewritePathsForRepo } from "./path-rewriter.js";
+import { scanDirectory } from "./scanner.js";
+
+/**
+ * Per-environment drift classification.
+ *
+ * Buckets follow the 3-way merge semantics used by `syncPull`:
+ *   - localOnly:    local differs from sync-repo HEAD, remote matches HEAD
+ *   - remoteOnly:   local matches HEAD, remote differs from HEAD
+ *   - bothChanged:  local and remote both differ from HEAD (a real conflict)
+ *   - stagedPending: entries currently staged for review under
+ *                    `<syncRepoDir>/.ai-sync/pending/` for this env.
+ */
+export interface DriftReport {
+	envName: string;
+	localOnly: string[];
+	remoteOnly: string[];
+	bothChanged: string[];
+	stagedPending: string[];
+}
+
+/**
+ * Reads the contents of `<ref>:<relPath>` from the git repo at `repoDir`.
+ * Returns `null` if the ref or file does not exist in that ref.
+ */
+async function readRefContent(
+	repoDir: string,
+	ref: string,
+	relPath: string,
+): Promise<string | null> {
+	try {
+		return await simpleGit(repoDir).show([`${ref}:${relPath}`]);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Returns true when the local repo has a tracking ref for `<ref>` (e.g.
+ * `origin/main`). Avoids throwing when the remote has never been fetched.
+ */
+async function refExists(repoDir: string, ref: string): Promise<boolean> {
+	try {
+		await simpleGit(repoDir).revparse([ref]);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Classifies drift between local config, sync-repo HEAD (base), and the
+ * remote tracking ref (origin/main) for a single environment.
+ *
+ * No network I/O is performed — callers are expected to have already
+ * fetched the remote if up-to-date remote drift is desired.
+ *
+ * The repoSubdir is derived from the repo's version: v2/v3 repos use
+ * `<syncRepoDir>/<env.id>/`, v1 repos use `<syncRepoDir>/` directly.
+ */
+export async function classifyDriftForEnv(
+	env: Environment,
+	syncRepoDir: string,
+	homeDir: string,
+): Promise<DriftReport> {
+	const configDir = env.getConfigDir();
+	const allowlistFn = makeAllowlistFn(env);
+	const version = await detectRepoVersion(syncRepoDir);
+	const repoSubdir = version === 1 ? syncRepoDir : path.join(syncRepoDir, env.id);
+	const repoSubdirRel = version === 1 ? "" : env.id;
+	const remoteRef = "origin/main";
+	const remoteAvailable = await refExists(syncRepoDir, remoteRef);
+
+	// Gather all files we need to consider: union of local + repo HEAD.
+	let localFiles: string[] = [];
+	try {
+		localFiles = await scanDirectory(configDir, allowlistFn);
+	} catch {
+		// Config dir absent — nothing local to compare
+	}
+
+	let repoFiles: string[] = [];
+	try {
+		repoFiles = await scanDirectory(repoSubdir, allowlistFn);
+	} catch {
+		// Repo subdir absent — first sync for this env
+	}
+
+	const allFiles = new Set<string>([...localFiles, ...repoFiles]);
+
+	const localOnly: string[] = [];
+	const remoteOnly: string[] = [];
+	const bothChanged: string[] = [];
+
+	for (const relativePath of allFiles) {
+		const rewrite = needsPathRewrite(relativePath, env);
+
+		// base = HEAD (sync repo content as currently committed)
+		let baseContent: string | null = null;
+		try {
+			baseContent = await fs.readFile(path.join(repoSubdir, relativePath), "utf-8");
+		} catch {
+			// File not present in repo HEAD
+		}
+
+		// local = local config content, normalized to repo form for fair comparison
+		let localContent: string | null = null;
+		try {
+			const raw = await fs.readFile(path.join(configDir, relativePath), "utf-8");
+			localContent = rewrite ? rewritePathsForRepo(raw, homeDir) : raw;
+		} catch {
+			// File not present locally
+		}
+
+		// remote = origin/main:<repoSubdirRel>/<relativePath>
+		const remoteRelPath = repoSubdirRel ? `${repoSubdirRel}/${relativePath}` : relativePath;
+		const remoteContent = remoteAvailable
+			? await readRefContent(syncRepoDir, remoteRef, remoteRelPath)
+			: baseContent;
+
+		const localChanged = localContent !== baseContent;
+		const remoteChanged = remoteAvailable && remoteContent !== baseContent;
+
+		if (!localChanged && !remoteChanged) continue;
+
+		if (localChanged && remoteChanged && localContent !== remoteContent) {
+			bothChanged.push(relativePath);
+		} else if (localChanged) {
+			localOnly.push(relativePath);
+		} else if (remoteChanged) {
+			remoteOnly.push(relativePath);
+		}
+	}
+
+	localOnly.sort();
+	remoteOnly.sort();
+	bothChanged.sort();
+
+	// Staged-pending entries scoped to this env.
+	let stagedPending: string[] = [];
+	try {
+		const staged = await listStaged(syncRepoDir);
+		stagedPending = staged
+			.filter((e) => e.envName === env.id)
+			.map((e) => e.relativePath)
+			.sort();
+	} catch {
+		// No manifest yet — leave empty
+	}
+
+	return {
+		envName: env.id,
+		localOnly,
+		remoteOnly,
+		bothChanged,
+		stagedPending,
+	};
+}
+
+/**
+ * Convenience wrapper: classifies drift for every passed-in environment.
+ */
+export async function classifyDrift(
+	envs: Environment[],
+	syncRepoDir: string,
+	homeDir: string,
+): Promise<DriftReport[]> {
+	const reports: DriftReport[] = [];
+	for (const env of envs) {
+		reports.push(await classifyDriftForEnv(env, syncRepoDir, homeDir));
+	}
+	return reports;
+}

--- a/tests/cli/commands/status.test.ts
+++ b/tests/cli/commands/status.test.ts
@@ -1,0 +1,272 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { simpleGit } from "simple-git";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleStatusDrift, printDriftReport } from "../../../src/cli/commands/status.js";
+import type { Environment } from "../../../src/core/environment.js";
+import { stage } from "../../../src/core/merge/staging.js";
+import { addFiles, addRemote, commitFiles, initRepo } from "../../../src/git/repo.js";
+
+function mockEnv(id: string, configDir: string): Environment {
+	return {
+		id,
+		displayName: id,
+		getConfigDir: () => configDir,
+		getSyncTargets: () => ["CLAUDE.md", "settings.json", "agents/", "commands/"],
+		getPluginSyncPatterns: () => [],
+		getIgnorePatterns: () => [],
+		getPathRewriteTargets: () => ["settings.json"],
+		getSkillsSubdir: () => "commands",
+	};
+}
+
+interface Fixture {
+	baseDir: string;
+	bareDir: string;
+	syncRepoDir: string;
+	homeDir: string;
+	claudeConfigDir: string;
+	opencodeConfigDir: string;
+	claudeEnv: Environment;
+	opencodeEnv: Environment;
+}
+
+async function makeFixture(): Promise<Fixture> {
+	const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "ai-sync-status-cli-"));
+	const bareDir = path.join(baseDir, "bare.git");
+	const syncRepoDir = path.join(baseDir, "sync-repo");
+	const homeDir = path.join(baseDir, "home");
+	const claudeConfigDir = path.join(homeDir, ".claude");
+	const opencodeConfigDir = path.join(homeDir, ".config", "opencode");
+
+	await fs.mkdir(bareDir, { recursive: true });
+	await simpleGit(bareDir).init(true);
+
+	await fs.mkdir(syncRepoDir, { recursive: true });
+	await initRepo(syncRepoDir);
+	await simpleGit(syncRepoDir).addConfig("user.email", "test@test.com");
+	await simpleGit(syncRepoDir).addConfig("user.name", "Test");
+	await addRemote(syncRepoDir, "origin", bareDir);
+	await fs.writeFile(path.join(syncRepoDir, ".sync-version"), "2");
+	await fs.writeFile(path.join(syncRepoDir, ".gitkeep"), "");
+
+	await fs.mkdir(path.join(syncRepoDir, "claude", "commands"), { recursive: true });
+	await fs.writeFile(path.join(syncRepoDir, "claude", "CLAUDE.md"), "base claude\n");
+	await fs.writeFile(path.join(syncRepoDir, "claude", "commands", "foo.md"), "foo\n");
+	await fs.mkdir(path.join(syncRepoDir, "opencode"), { recursive: true });
+	await fs.writeFile(path.join(syncRepoDir, "opencode", "settings.json"), '{"theme":"base"}');
+
+	await addFiles(syncRepoDir, [
+		".gitkeep",
+		".sync-version",
+		"claude/CLAUDE.md",
+		"claude/commands/foo.md",
+		"opencode/settings.json",
+	]);
+	await commitFiles(syncRepoDir, "initial");
+	await simpleGit(syncRepoDir).push("origin", "main");
+	await simpleGit(syncRepoDir).branch(["--set-upstream-to=origin/main", "main"]);
+
+	await fs.mkdir(path.join(claudeConfigDir, "commands"), { recursive: true });
+	await fs.writeFile(path.join(claudeConfigDir, "CLAUDE.md"), "base claude\n");
+	await fs.writeFile(path.join(claudeConfigDir, "commands", "foo.md"), "foo\n");
+	await fs.mkdir(opencodeConfigDir, { recursive: true });
+	await fs.writeFile(path.join(opencodeConfigDir, "settings.json"), '{"theme":"base"}');
+
+	return {
+		baseDir,
+		bareDir,
+		syncRepoDir,
+		homeDir,
+		claudeConfigDir,
+		opencodeConfigDir,
+		claudeEnv: mockEnv("claude", claudeConfigDir),
+		opencodeEnv: mockEnv("opencode", opencodeConfigDir),
+	};
+}
+
+async function pushRemote(fx: Fixture, relPath: string, content: string): Promise<void> {
+	const cloneDir = path.join(fx.baseDir, `clone-${Math.random().toString(36).slice(2, 8)}`);
+	await simpleGit().clone(fx.bareDir, cloneDir);
+	await simpleGit(cloneDir).addConfig("user.email", "r@t.com");
+	await simpleGit(cloneDir).addConfig("user.name", "R");
+	const t = path.join(cloneDir, relPath);
+	await fs.mkdir(path.dirname(t), { recursive: true });
+	await fs.writeFile(t, content);
+	await addFiles(cloneDir, [relPath]);
+	await commitFiles(cloneDir, "remote");
+	await simpleGit(cloneDir).push("origin", "main");
+}
+
+let fx: Fixture;
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(async () => {
+	fx = await makeFixture();
+	logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+	logSpy.mockRestore();
+	await fs.rm(fx.baseDir, { recursive: true, force: true });
+});
+
+function logged(): string {
+	return logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+}
+
+describe("handleStatusDrift", () => {
+	it("reports all zero counts in a clean state", async () => {
+		const reports = await handleStatusDrift({
+			repoPath: fx.syncRepoDir,
+			homeDir: fx.homeDir,
+			environments: [fx.claudeEnv, fx.opencodeEnv],
+		});
+		expect(reports).toHaveLength(2);
+		for (const r of reports) {
+			expect(r.localOnly).toEqual([]);
+			expect(r.remoteOnly).toEqual([]);
+			expect(r.bothChanged).toEqual([]);
+			expect(r.stagedPending).toEqual([]);
+		}
+	});
+
+	it("identifies a local-only change", async () => {
+		await fs.writeFile(path.join(fx.claudeConfigDir, "CLAUDE.md"), "local!\n");
+		const reports = await handleStatusDrift({
+			repoPath: fx.syncRepoDir,
+			homeDir: fx.homeDir,
+			environments: [fx.claudeEnv],
+		});
+		expect(reports[0].localOnly).toEqual(["CLAUDE.md"]);
+	});
+
+	it("identifies a remote-only change after fetch", async () => {
+		await pushRemote(fx, "claude/CLAUDE.md", "remote!\n");
+		const reports = await handleStatusDrift({
+			repoPath: fx.syncRepoDir,
+			homeDir: fx.homeDir,
+			environments: [fx.claudeEnv],
+		});
+		expect(reports[0].remoteOnly).toEqual(["CLAUDE.md"]);
+	});
+
+	it("identifies a both-changed conflict", async () => {
+		await fs.writeFile(path.join(fx.claudeConfigDir, "CLAUDE.md"), "local!\n");
+		await pushRemote(fx, "claude/CLAUDE.md", "remote!\n");
+		const reports = await handleStatusDrift({
+			repoPath: fx.syncRepoDir,
+			homeDir: fx.homeDir,
+			environments: [fx.claudeEnv],
+		});
+		expect(reports[0].bothChanged).toEqual(["CLAUDE.md"]);
+	});
+
+	it("counts staged-pending merges per env", async () => {
+		await stage(fx.syncRepoDir, {
+			envName: "claude",
+			relativePath: "CLAUDE.md",
+			mergedContent: "merged",
+			resolver: "stub",
+		});
+		const reports = await handleStatusDrift({
+			repoPath: fx.syncRepoDir,
+			homeDir: fx.homeDir,
+			environments: [fx.claudeEnv, fx.opencodeEnv],
+		});
+		const claude = reports.find((r) => r.envName === "claude");
+		const open = reports.find((r) => r.envName === "opencode");
+		expect(claude?.stagedPending).toEqual(["CLAUDE.md"]);
+		expect(open?.stagedPending).toEqual([]);
+	});
+
+	it("filters with --env option", async () => {
+		const reports = await handleStatusDrift({
+			repoPath: fx.syncRepoDir,
+			homeDir: fx.homeDir,
+			environments: [fx.claudeEnv, fx.opencodeEnv],
+			env: "opencode",
+		});
+		expect(reports.map((r) => r.envName)).toEqual(["opencode"]);
+	});
+});
+
+describe("printDriftReport", () => {
+	it("prints per-env counts on a single line", () => {
+		printDriftReport(
+			[
+				{
+					envName: "claude",
+					localOnly: ["a.md"],
+					remoteOnly: [],
+					bothChanged: [],
+					stagedPending: [],
+				},
+			],
+			false,
+		);
+		const out = logged();
+		expect(out).toContain("claude");
+		expect(out).toContain("local-only=1");
+		expect(out).toContain("remote-only=0");
+		expect(out).toContain("both-changed=0");
+		expect(out).toContain("staged-pending=0");
+		// Filenames should NOT appear without --verbose
+		expect(out).not.toContain("a.md");
+	});
+
+	it("lists filenames under each bucket when verbose", () => {
+		printDriftReport(
+			[
+				{
+					envName: "claude",
+					localOnly: ["a.md"],
+					remoteOnly: ["b.md"],
+					bothChanged: ["c.md"],
+					stagedPending: ["d.md"],
+				},
+			],
+			true,
+		);
+		const out = logged();
+		expect(out).toContain("a.md");
+		expect(out).toContain("b.md");
+		expect(out).toContain("c.md");
+		expect(out).toContain("d.md");
+		expect(out).toMatch(/local-only:/);
+		expect(out).toMatch(/remote-only:/);
+		expect(out).toMatch(/both-changed:/);
+		expect(out).toMatch(/staged-pending:/);
+	});
+
+	it("prints one header line per environment", () => {
+		printDriftReport(
+			[
+				{
+					envName: "claude",
+					localOnly: [],
+					remoteOnly: [],
+					bothChanged: [],
+					stagedPending: [],
+				},
+				{
+					envName: "opencode",
+					localOnly: [],
+					remoteOnly: [],
+					bothChanged: [],
+					stagedPending: [],
+				},
+			],
+			false,
+		);
+		const out = logged();
+		expect(out).toMatch(/Env claude:/);
+		expect(out).toMatch(/Env opencode:/);
+	});
+
+	it("prints a dim placeholder when no envs are passed", () => {
+		printDriftReport([], false);
+		expect(logged()).toMatch(/No environments enabled/);
+	});
+});

--- a/tests/core/drift.test.ts
+++ b/tests/core/drift.test.ts
@@ -1,0 +1,199 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { simpleGit } from "simple-git";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { classifyDrift, classifyDriftForEnv } from "../../src/core/drift.js";
+import type { Environment } from "../../src/core/environment.js";
+import { stage } from "../../src/core/merge/staging.js";
+import { addFiles, addRemote, commitFiles, initRepo } from "../../src/git/repo.js";
+
+function mockEnv(id: string, configDir: string): Environment {
+	return {
+		id,
+		displayName: id,
+		getConfigDir: () => configDir,
+		getSyncTargets: () => ["CLAUDE.md", "settings.json", "agents/", "commands/"],
+		getPluginSyncPatterns: () => [],
+		getIgnorePatterns: () => [],
+		getPathRewriteTargets: () => ["settings.json"],
+		getSkillsSubdir: () => "commands",
+	};
+}
+
+interface V2Fixture {
+	baseDir: string;
+	bareDir: string;
+	syncRepoDir: string;
+	homeDir: string;
+	claudeConfigDir: string;
+	claudeEnv: Environment;
+	opencodeEnv: Environment;
+	opencodeConfigDir: string;
+}
+
+async function makeV2Fixture(): Promise<V2Fixture> {
+	const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "ai-sync-drift-"));
+	const bareDir = path.join(baseDir, "bare.git");
+	const syncRepoDir = path.join(baseDir, "sync-repo");
+	const homeDir = path.join(baseDir, "home");
+	const claudeConfigDir = path.join(homeDir, ".claude");
+	const opencodeConfigDir = path.join(homeDir, ".config", "opencode");
+
+	await fs.mkdir(bareDir, { recursive: true });
+	await simpleGit(bareDir).init(true);
+
+	await fs.mkdir(syncRepoDir, { recursive: true });
+	await initRepo(syncRepoDir);
+	await simpleGit(syncRepoDir).addConfig("user.email", "test@test.com");
+	await simpleGit(syncRepoDir).addConfig("user.name", "Test");
+	await addRemote(syncRepoDir, "origin", bareDir);
+	await fs.writeFile(path.join(syncRepoDir, ".sync-version"), "2");
+	await fs.writeFile(path.join(syncRepoDir, ".gitkeep"), "");
+
+	// Seed claude env with a CLAUDE.md and a commands/foo.md committed at HEAD
+	await fs.mkdir(path.join(syncRepoDir, "claude", "commands"), { recursive: true });
+	await fs.writeFile(path.join(syncRepoDir, "claude", "CLAUDE.md"), "base claude\n");
+	await fs.writeFile(path.join(syncRepoDir, "claude", "commands", "foo.md"), "base foo\n");
+
+	// Seed opencode env with a settings.json
+	await fs.mkdir(path.join(syncRepoDir, "opencode"), { recursive: true });
+	await fs.writeFile(path.join(syncRepoDir, "opencode", "settings.json"), '{"theme":"base"}');
+
+	await addFiles(syncRepoDir, [
+		".gitkeep",
+		".sync-version",
+		"claude/CLAUDE.md",
+		"claude/commands/foo.md",
+		"opencode/settings.json",
+	]);
+	await commitFiles(syncRepoDir, "initial");
+	await simpleGit(syncRepoDir).push("origin", "main");
+	await simpleGit(syncRepoDir).branch(["--set-upstream-to=origin/main", "main"]);
+
+	// Mirror committed content into local config dirs so the baseline is clean.
+	await fs.mkdir(path.join(claudeConfigDir, "commands"), { recursive: true });
+	await fs.writeFile(path.join(claudeConfigDir, "CLAUDE.md"), "base claude\n");
+	await fs.writeFile(path.join(claudeConfigDir, "commands", "foo.md"), "base foo\n");
+	await fs.mkdir(opencodeConfigDir, { recursive: true });
+	await fs.writeFile(path.join(opencodeConfigDir, "settings.json"), '{"theme":"base"}');
+
+	return {
+		baseDir,
+		bareDir,
+		syncRepoDir,
+		homeDir,
+		claudeConfigDir,
+		opencodeConfigDir,
+		claudeEnv: mockEnv("claude", claudeConfigDir),
+		opencodeEnv: mockEnv("opencode", opencodeConfigDir),
+	};
+}
+
+/**
+ * Simulates a remote-side change by committing into a clone and pushing,
+ * then fetching back into syncRepoDir (without merging).
+ */
+async function pushRemoteChange(
+	fx: V2Fixture,
+	relPathInRepo: string,
+	newContent: string,
+): Promise<void> {
+	const cloneDir = path.join(
+		fx.baseDir,
+		`clone-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+	);
+	await simpleGit().clone(fx.bareDir, cloneDir);
+	await simpleGit(cloneDir).addConfig("user.email", "remote@test.com");
+	await simpleGit(cloneDir).addConfig("user.name", "Remote");
+	const target = path.join(cloneDir, relPathInRepo);
+	await fs.mkdir(path.dirname(target), { recursive: true });
+	await fs.writeFile(target, newContent);
+	await addFiles(cloneDir, [relPathInRepo]);
+	await commitFiles(cloneDir, `remote: change ${relPathInRepo}`);
+	await simpleGit(cloneDir).push("origin", "main");
+	await simpleGit(fx.syncRepoDir).fetch("origin");
+}
+
+let fx: V2Fixture;
+
+beforeEach(async () => {
+	fx = await makeV2Fixture();
+});
+
+afterEach(async () => {
+	await fs.rm(fx.baseDir, { recursive: true, force: true });
+});
+
+describe("classifyDriftForEnv", () => {
+	it("reports zero drift when local and remote match HEAD", async () => {
+		const report = await classifyDriftForEnv(fx.claudeEnv, fx.syncRepoDir, fx.homeDir);
+		expect(report.localOnly).toEqual([]);
+		expect(report.remoteOnly).toEqual([]);
+		expect(report.bothChanged).toEqual([]);
+		expect(report.stagedPending).toEqual([]);
+	});
+
+	it("counts a local-only modification", async () => {
+		await fs.writeFile(path.join(fx.claudeConfigDir, "CLAUDE.md"), "local change\n");
+		const report = await classifyDriftForEnv(fx.claudeEnv, fx.syncRepoDir, fx.homeDir);
+		expect(report.localOnly).toEqual(["CLAUDE.md"]);
+		expect(report.remoteOnly).toEqual([]);
+		expect(report.bothChanged).toEqual([]);
+	});
+
+	it("counts a local-only addition", async () => {
+		await fs.writeFile(path.join(fx.claudeConfigDir, "commands", "new.md"), "fresh");
+		const report = await classifyDriftForEnv(fx.claudeEnv, fx.syncRepoDir, fx.homeDir);
+		expect(report.localOnly).toEqual(["commands/new.md"]);
+	});
+
+	it("counts a remote-only modification", async () => {
+		await pushRemoteChange(fx, "claude/CLAUDE.md", "remote change\n");
+		const report = await classifyDriftForEnv(fx.claudeEnv, fx.syncRepoDir, fx.homeDir);
+		expect(report.remoteOnly).toEqual(["CLAUDE.md"]);
+		expect(report.localOnly).toEqual([]);
+		expect(report.bothChanged).toEqual([]);
+	});
+
+	it("counts a both-changed conflict", async () => {
+		await fs.writeFile(path.join(fx.claudeConfigDir, "CLAUDE.md"), "local change\n");
+		await pushRemoteChange(fx, "claude/CLAUDE.md", "remote change\n");
+		const report = await classifyDriftForEnv(fx.claudeEnv, fx.syncRepoDir, fx.homeDir);
+		expect(report.bothChanged).toEqual(["CLAUDE.md"]);
+		expect(report.localOnly).toEqual([]);
+		expect(report.remoteOnly).toEqual([]);
+	});
+
+	it("counts staged-pending entries scoped to env", async () => {
+		await stage(fx.syncRepoDir, {
+			envName: "claude",
+			relativePath: "CLAUDE.md",
+			mergedContent: "merged",
+			resolver: "stub",
+		});
+		await stage(fx.syncRepoDir, {
+			envName: "opencode",
+			relativePath: "settings.json",
+			mergedContent: "merged2",
+			resolver: "stub",
+		});
+		const claudeReport = await classifyDriftForEnv(fx.claudeEnv, fx.syncRepoDir, fx.homeDir);
+		expect(claudeReport.stagedPending).toEqual(["CLAUDE.md"]);
+		const openReport = await classifyDriftForEnv(fx.opencodeEnv, fx.syncRepoDir, fx.homeDir);
+		expect(openReport.stagedPending).toEqual(["settings.json"]);
+	});
+});
+
+describe("classifyDrift (multi-env)", () => {
+	it("returns one report per environment", async () => {
+		await fs.writeFile(path.join(fx.claudeConfigDir, "CLAUDE.md"), "local!\n");
+		await pushRemoteChange(fx, "opencode/settings.json", '{"theme":"remote"}');
+		const reports = await classifyDrift([fx.claudeEnv, fx.opencodeEnv], fx.syncRepoDir, fx.homeDir);
+		expect(reports.map((r) => r.envName)).toEqual(["claude", "opencode"]);
+		const claude = reports.find((r) => r.envName === "claude");
+		const opencode = reports.find((r) => r.envName === "opencode");
+		expect(claude?.localOnly).toEqual(["CLAUDE.md"]);
+		expect(opencode?.remoteOnly).toEqual(["settings.json"]);
+	});
+});


### PR DESCRIPTION
Closes #29

## Summary

- Adds an `ai-sync status` drift report that prints per-env counts of `local-only`, `remote-only`, `both-changed`, and `staged-pending` files.
- `--verbose` lists the filenames under each non-empty bucket.
- Extracts the 3-way drift classification into a reusable `src/core/drift.ts` helper so #30 (`--summarize`) can share it without duplicating sync-engine logic.
- `--claude-dir` (legacy v1) builds a synthetic Claude environment so the drift report stays scoped to the requested config dir instead of the operator's real home.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (changed files)
- [x] `npm test -- tests/core/drift.test.ts tests/cli/commands/status.test.ts tests/commands/status.test.ts` (30/30 pass)
- [x] `npm run build`
- [ ] CI green