### PR TITLE
feat(cli): ai-sync status --summarize

### DIFF
--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -6,6 +6,10 @@ import pc from "picocolors";
 import { classifyDrift, type DriftReport } from "../../core/drift.js";
 import { getEnabledEnvironmentInstances } from "../../core/env-config.js";
 import type { Environment } from "../../core/environment.js";
+import { createAdapter } from "../../core/merge/adapters/index.js";
+import { loadMergeConfig } from "../../core/merge/config.js";
+import { buildSummaryPrompt, type SummaryDiffData } from "../../core/merge/prompts.js";
+import { summarizeWithResolver } from "../../core/merge/summarize.js";
 import { verifyTool } from "../../core/provisioner.js";
 import type { SyncStatusResult } from "../../core/sync-engine.js";
 import { syncStatus } from "../../core/sync-engine.js";
@@ -13,6 +17,9 @@ import { ToolManifestSchema } from "../../core/tool-manifest.js";
 import { fetchRemote, hasRemote } from "../../git/repo.js";
 import { getClaudeDir, getSyncRepoDir } from "../../platform/paths.js";
 import { printFileChanges } from "../format.js";
+
+/** Maximum number of lines of file-path payload to ship to the resolver per env. */
+const SUMMARIZE_LINE_CAP = 200;
 
 /**
  * Options for the status command handler.
@@ -22,10 +29,32 @@ export interface StatusOptions {
 	claudeDir?: string;
 	env?: string;
 	verbose?: boolean;
+	/** Opt-in: ask the configured resolver to produce a drift summary. */
+	summarize?: boolean;
 	/** Override the environment list (testing). */
 	environments?: Environment[];
 	/** Override the home dir used for path-rewrite normalization (testing). */
 	homeDir?: string;
+	/** Test seam: override the availability probe (`adapter.available()`). */
+	availableFn?: (resolverName: string) => Promise<boolean>;
+	/** Test seam: override the resolver invocation used for summarize. */
+	summarizeFn?: (resolverName: string, prompt: string) => Promise<string>;
+}
+
+/**
+ * Aggregated outcome of `ai-sync status --summarize` per env. Exported for
+ * tests that want to assert resolver invocation count without parsing
+ * stdout.
+ */
+export interface SummarizeResult {
+	envName: string;
+	/** "ok" — resolver returned a summary; text is in `summary`. */
+	/** "skipped-no-drift" — env had zero drift, resolver not invoked. */
+	/** "unavailable" — adapter.available() returned false. */
+	/** "error" — resolver call rejected; message captured. */
+	status: "ok" | "skipped-no-drift" | "unavailable" | "error";
+	summary?: string;
+	error?: string;
 }
 
 /**
@@ -146,6 +175,122 @@ export function printDriftReport(reports: DriftReport[], verbose: boolean): void
 }
 
 /**
+ * Translates a drift report into the SummaryDiffData payload, capping the
+ * combined entry count so we never ship an unbounded prompt to the
+ * resolver.
+ */
+function buildDiffDataFromReport(r: DriftReport, lineCap: number): SummaryDiffData {
+	const data: SummaryDiffData = { localOnly: [], remoteOnly: [], bothChanged: [] };
+	let remaining = lineCap;
+	const push = (
+		bucket: "localOnly" | "remoteOnly" | "bothChanged",
+		files: string[],
+		side: "local" | "remote" | "both",
+	): void => {
+		for (const relativePath of files) {
+			if (remaining <= 0) return;
+			data[bucket].push({ relativePath, side });
+			remaining--;
+		}
+	};
+	push("bothChanged", r.bothChanged, "both");
+	push("localOnly", r.localOnly, "local");
+	push("remoteOnly", r.remoteOnly, "remote");
+	return data;
+}
+
+/**
+ * Default availability probe — instantiates the configured adapter and
+ * delegates to `adapter.available()`.
+ */
+async function defaultAvailable(resolverName: string): Promise<boolean> {
+	const adapter = createAdapter(resolverName as "claude" | "codex" | "opencode");
+	return adapter.available();
+}
+
+/**
+ * Runs the resolver in "summarize differences" mode for every env that
+ * has any drift. Returns one entry per env in the input order so callers
+ * can render output in a deterministic layout. Never throws — resolver
+ * failures are captured per-env.
+ */
+export async function handleStatusSummarize(
+	reports: DriftReport[],
+	resolverName: "claude" | "codex" | "opencode",
+	options: {
+		availableFn?: (name: string) => Promise<boolean>;
+		summarizeFn?: (name: string, prompt: string) => Promise<string>;
+		timeoutMs?: number;
+	} = {},
+): Promise<SummarizeResult[]> {
+	const availableFn = options.availableFn ?? defaultAvailable;
+	const summarizeFn =
+		options.summarizeFn ??
+		((name, prompt) =>
+			summarizeWithResolver(name as "claude" | "codex" | "opencode", prompt, {
+				timeoutMs: options.timeoutMs,
+			}));
+
+	// Probe availability once — the same resolver is used for every env.
+	let isAvailable = false;
+	try {
+		isAvailable = await availableFn(resolverName);
+	} catch {
+		isAvailable = false;
+	}
+
+	const results: SummarizeResult[] = [];
+	for (const r of reports) {
+		const hasDrift = r.localOnly.length + r.remoteOnly.length + r.bothChanged.length > 0;
+		if (!hasDrift) {
+			results.push({ envName: r.envName, status: "skipped-no-drift" });
+			continue;
+		}
+		if (!isAvailable) {
+			results.push({ envName: r.envName, status: "unavailable" });
+			continue;
+		}
+		const diffData = buildDiffDataFromReport(r, SUMMARIZE_LINE_CAP);
+		const prompt = buildSummaryPrompt(r.envName, diffData);
+		try {
+			const summary = await summarizeFn(resolverName, prompt);
+			results.push({ envName: r.envName, status: "ok", summary: summary.trim() });
+		} catch (err) {
+			results.push({
+				envName: r.envName,
+				status: "error",
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	}
+	return results;
+}
+
+/**
+ * Renders summarize results under each env header. Mirrors
+ * {@link printDriftReport} formatting conventions.
+ */
+export function printSummarizeResults(results: SummarizeResult[], resolverName: string): void {
+	for (const r of results) {
+		if (r.status === "ok") {
+			console.log(pc.cyan(`  Summary (via ${resolverName}):`));
+			for (const line of (r.summary ?? "").split("\n")) {
+				console.log(`    ${line}`);
+			}
+		} else if (r.status === "unavailable") {
+			console.log(
+				pc.yellow(
+					`  Resolver '${resolverName}' not available — install or change tools/merge-config.json`,
+				),
+			);
+		} else if (r.status === "error") {
+			console.log(pc.yellow(`  Summary skipped for ${r.envName}: ${r.error ?? "unknown error"}`));
+		}
+		// skipped-no-drift: silent — counts already showed 0s.
+	}
+}
+
+/**
  * Registers the "status" subcommand on the CLI program.
  */
 export function registerStatusCommand(program: Command): void {
@@ -156,6 +301,11 @@ export function registerStatusCommand(program: Command): void {
 		.option("--claude-dir <path>", "Custom ~/.claude path", getClaudeDir())
 		.option("-v, --verbose", "Show detailed sync info", false)
 		.option("--env <id>", "Show status for a specific environment only")
+		.option(
+			"--summarize",
+			"Invoke the configured AI resolver to produce a natural-language drift summary",
+			false,
+		)
 		.action(async (opts) => {
 			try {
 				const result = await handleStatus(opts);
@@ -169,6 +319,25 @@ export function registerStatusCommand(program: Command): void {
 				try {
 					const drift = await handleStatusDrift(opts);
 					printDriftReport(drift, !!opts.verbose);
+					if (opts.summarize) {
+						try {
+							const mergeConfig = await loadMergeConfig(opts.repoPath ?? getSyncRepoDir());
+							const results = await handleStatusSummarize(drift, mergeConfig.resolver, {
+								availableFn: opts.availableFn,
+								summarizeFn: opts.summarizeFn,
+								timeoutMs: mergeConfig.timeoutSeconds * 1000,
+							});
+							printSummarizeResults(results, mergeConfig.resolver);
+						} catch (summaryErr) {
+							console.log(
+								pc.yellow(
+									`Summary skipped: ${
+										summaryErr instanceof Error ? summaryErr.message : String(summaryErr)
+									}`,
+								),
+							);
+						}
+					}
 				} catch (driftErr) {
 					if (opts.verbose) {
 						console.error(

--- a/src/core/merge/prompts.ts
+++ b/src/core/merge/prompts.ts
@@ -1,6 +1,66 @@
 import type { FileType } from "./resolver.js";
 
 /**
+ * Per-env drift payload used to build a summary prompt. Mirrors the shape
+ * of {@link import("../drift.js").DriftReport} but with optional content
+ * snippets per file so the resolver can produce a meaningful natural-
+ * language summary.
+ */
+export interface SummaryDiffEntry {
+	relativePath: string;
+	side: "local" | "remote" | "both";
+	/** Optional preview of what changed (already capped by caller). */
+	snippet?: string;
+}
+
+export interface SummaryDiffData {
+	localOnly: SummaryDiffEntry[];
+	remoteOnly: SummaryDiffEntry[];
+	bothChanged: SummaryDiffEntry[];
+}
+
+/**
+ * Builds the prompt used by the resolver when invoked in "summarize
+ * differences" mode by `ai-sync status --summarize`.
+ *
+ * The prompt aggregates the per-env drift classification into a single
+ * structured request so the resolver returns a short natural-language
+ * description of what each side changed. The caller is responsible for
+ * capping the payload (e.g. 200 lines per env) before invoking this.
+ */
+export function buildSummaryPrompt(envName: string, diffData: SummaryDiffData): string {
+	const lines: string[] = [];
+	lines.push(
+		`You are summarizing configuration drift for the "${envName}" environment.`,
+		"Read the lists below and produce a concise natural-language summary (2-5 sentences)",
+		"describing what changed on each side. Do not propose merges — just describe the drift.",
+		"Respond with ONLY the summary text. No code fences, no headings, no prose preamble.",
+		"",
+	);
+	const renderBucket = (label: string, entries: SummaryDiffEntry[]): void => {
+		lines.push(`<${label}>`);
+		if (entries.length === 0) {
+			lines.push("(none)");
+		} else {
+			for (const e of entries) {
+				lines.push(`- ${e.relativePath}`);
+				if (e.snippet && e.snippet.length > 0) {
+					for (const sline of e.snippet.split("\n")) {
+						lines.push(`    ${sline}`);
+					}
+				}
+			}
+		}
+		lines.push(`</${label}>`);
+		lines.push("");
+	};
+	renderBucket("LOCAL_ONLY", diffData.localOnly);
+	renderBucket("REMOTE_ONLY", diffData.remoteOnly);
+	renderBucket("BOTH_CHANGED", diffData.bothChanged);
+	return lines.join("\n");
+}
+
+/**
  * Build the merge prompt presented to the resolver CLI.
  *
  * v1 emits a single uniform prompt for all file types. Per-type variation

--- a/src/core/merge/summarize.ts
+++ b/src/core/merge/summarize.ts
@@ -1,0 +1,101 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { defaultExecFn, type ExecFn } from "./adapters/claude-cli.js";
+import type { AdapterName } from "./adapters/index.js";
+import { ResolverError } from "./resolver.js";
+
+/**
+ * CLI invocation shape per resolver. Mirrors the per-adapter `resolve()`
+ * argv used internally; centralized here so `ai-sync status --summarize`
+ * can drive any configured resolver with a custom prompt without
+ * duplicating the merge-specific MergeInput plumbing.
+ */
+function buildArgv(resolver: AdapterName, promptFile: string): { binary: string; args: string[] } {
+	switch (resolver) {
+		case "claude":
+			return { binary: "claude", args: ["-p", promptFile] };
+		case "codex":
+			return { binary: "codex", args: ["exec", "--prompt-file", promptFile] };
+		case "opencode":
+			return { binary: "opencode", args: ["run", promptFile] };
+	}
+}
+
+export interface SummarizeOptions {
+	timeoutMs?: number;
+	tmpdirRoot?: string;
+	execFn?: ExecFn;
+}
+
+/**
+ * Invokes a configured resolver CLI with a freeform prompt and returns
+ * stdout. Used by `ai-sync status --summarize` — one call per env.
+ *
+ * Errors are wrapped in {@link ResolverError} so callers can surface a
+ * single yellow warning line without aborting the rest of the report.
+ */
+export async function summarizeWithResolver(
+	resolver: AdapterName,
+	prompt: string,
+	options: SummarizeOptions = {},
+): Promise<string> {
+	const execFn = options.execFn ?? defaultExecFn;
+	const timeoutMs = options.timeoutMs ?? 60_000;
+	const tmpdirRoot = options.tmpdirRoot ?? os.tmpdir();
+
+	const id = crypto.randomBytes(6).toString("hex");
+	const tempdir = path.join(tmpdirRoot, `ai-sync-summary-${process.pid}-${id}`);
+	await fs.mkdir(tempdir, { recursive: true });
+	const promptFile = path.join(tempdir, "prompt.txt");
+	try {
+		await fs.writeFile(promptFile, prompt, "utf-8");
+	} catch (err) {
+		throw new ResolverError(
+			"io-error",
+			`Failed to prepare tempdir ${tempdir}: ${(err as Error).message}`,
+			{ tempdir, cause: err },
+		);
+	}
+
+	const { binary, args } = buildArgv(resolver, promptFile);
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+	let result: { stdout: string; stderr: string };
+	try {
+		result = await execFn(binary, args, { signal: controller.signal });
+	} catch (err) {
+		const e = err as NodeJS.ErrnoException & { code?: string };
+		if (controller.signal.aborted || e.code === "ABORT_ERR" || e.name === "AbortError") {
+			throw new ResolverError(
+				"timeout",
+				`${resolver} exceeded timeout of ${timeoutMs}ms (tempdir: ${tempdir})`,
+				{ tempdir, cause: err },
+			);
+		}
+		throw new ResolverError(
+			"non-zero-exit",
+			`${resolver} exited non-zero: ${(err as Error).message} (tempdir: ${tempdir})`,
+			{ tempdir, cause: err },
+		);
+	} finally {
+		clearTimeout(timer);
+	}
+
+	const out = result.stdout;
+	if (typeof out !== "string" || out.length === 0) {
+		throw new ResolverError(
+			"malformed-output",
+			`${resolver} returned empty stdout (tempdir: ${tempdir})`,
+			{ tempdir },
+		);
+	}
+
+	try {
+		await fs.rm(tempdir, { recursive: true, force: true });
+	} catch {
+		// Best-effort cleanup.
+	}
+	return out;
+}

--- a/tests/cli/commands/status.test.ts
+++ b/tests/cli/commands/status.test.ts
@@ -3,7 +3,13 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { simpleGit } from "simple-git";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { handleStatusDrift, printDriftReport } from "../../../src/cli/commands/status.js";
+import {
+	handleStatusDrift,
+	handleStatusSummarize,
+	printDriftReport,
+	printSummarizeResults,
+} from "../../../src/cli/commands/status.js";
+import type { DriftReport } from "../../../src/core/drift.js";
 import type { Environment } from "../../../src/core/environment.js";
 import { stage } from "../../../src/core/merge/staging.js";
 import { addFiles, addRemote, commitFiles, initRepo } from "../../../src/git/repo.js";
@@ -268,5 +274,144 @@ describe("printDriftReport", () => {
 	it("prints a dim placeholder when no envs are passed", () => {
 		printDriftReport([], false);
 		expect(logged()).toMatch(/No environments enabled/);
+	});
+});
+
+function makeReport(envName: string, overrides: Partial<DriftReport> = {}): DriftReport {
+	return {
+		envName,
+		localOnly: [],
+		remoteOnly: [],
+		bothChanged: [],
+		stagedPending: [],
+		...overrides,
+	};
+}
+
+describe("handleStatusSummarize", () => {
+	it("does NOT invoke the resolver when every env is clean", async () => {
+		const available = vi.fn().mockResolvedValue(true);
+		const summarize = vi.fn().mockResolvedValue("never called");
+		const results = await handleStatusSummarize(
+			[makeReport("claude"), makeReport("opencode")],
+			"claude",
+			{ availableFn: available, summarizeFn: summarize },
+		);
+		expect(summarize).not.toHaveBeenCalled();
+		expect(results.every((r) => r.status === "skipped-no-drift")).toBe(true);
+	});
+
+	it("invokes the resolver exactly once per env-with-drift and returns summaries", async () => {
+		const available = vi.fn().mockResolvedValue(true);
+		const summarize = vi
+			.fn()
+			.mockImplementation(async (_name: string, prompt: string) =>
+				prompt.includes("claude") ? "claude moved CLAUDE.md" : "opencode tweaked theme",
+			);
+		const reports = [
+			makeReport("claude", { localOnly: ["CLAUDE.md"] }),
+			makeReport("opencode", { remoteOnly: ["settings.json"] }),
+		];
+		const results = await handleStatusSummarize(reports, "claude", {
+			availableFn: available,
+			summarizeFn: summarize,
+		});
+		expect(summarize).toHaveBeenCalledTimes(2);
+		expect(results.find((r) => r.envName === "claude")?.status).toBe("ok");
+		expect(results.find((r) => r.envName === "claude")?.summary).toMatch(/claude moved/);
+		expect(results.find((r) => r.envName === "opencode")?.summary).toMatch(/opencode tweaked/);
+	});
+
+	it("does not call the resolver per-file — a single env-with-drift yields one call", async () => {
+		const available = vi.fn().mockResolvedValue(true);
+		const summarize = vi.fn().mockResolvedValue("ok");
+		await handleStatusSummarize(
+			[
+				makeReport("claude", {
+					localOnly: ["a.md", "b.md", "c.md"],
+					remoteOnly: ["d.md"],
+					bothChanged: ["e.md"],
+				}),
+			],
+			"claude",
+			{ availableFn: available, summarizeFn: summarize },
+		);
+		expect(summarize).toHaveBeenCalledTimes(1);
+	});
+
+	it("marks env as unavailable when adapter.available() returns false and never invokes resolver", async () => {
+		const available = vi.fn().mockResolvedValue(false);
+		const summarize = vi.fn().mockResolvedValue("never");
+		const results = await handleStatusSummarize(
+			[makeReport("claude", { localOnly: ["CLAUDE.md"] })],
+			"claude",
+			{ availableFn: available, summarizeFn: summarize },
+		);
+		expect(summarize).not.toHaveBeenCalled();
+		expect(results[0].status).toBe("unavailable");
+	});
+
+	it("captures resolver errors per-env without aborting the report", async () => {
+		const available = vi.fn().mockResolvedValue(true);
+		const summarize = vi
+			.fn()
+			.mockImplementationOnce(async () => {
+				throw new Error("boom");
+			})
+			.mockImplementationOnce(async () => "fine");
+		const results = await handleStatusSummarize(
+			[
+				makeReport("claude", { localOnly: ["a.md"] }),
+				makeReport("opencode", { localOnly: ["b.md"] }),
+			],
+			"claude",
+			{ availableFn: available, summarizeFn: summarize },
+		);
+		expect(results[0].status).toBe("error");
+		expect(results[0].error).toMatch(/boom/);
+		expect(results[1].status).toBe("ok");
+		expect(results[1].summary).toBe("fine");
+	});
+
+	it("treats availableFn rejection as unavailable", async () => {
+		const available = vi.fn().mockRejectedValue(new Error("probe failed"));
+		const summarize = vi.fn().mockResolvedValue("never");
+		const results = await handleStatusSummarize(
+			[makeReport("claude", { localOnly: ["a.md"] })],
+			"claude",
+			{ availableFn: available, summarizeFn: summarize },
+		);
+		expect(summarize).not.toHaveBeenCalled();
+		expect(results[0].status).toBe("unavailable");
+	});
+});
+
+describe("printSummarizeResults", () => {
+	it("prints the summary text under the env header for ok results", () => {
+		printSummarizeResults(
+			[{ envName: "claude", status: "ok", summary: "two-line\nsummary" }],
+			"claude",
+		);
+		const out = logged();
+		expect(out).toMatch(/Summary \(via claude\):/);
+		expect(out).toContain("two-line");
+		expect(out).toContain("summary");
+	});
+
+	it("prints a yellow warning when the resolver is unavailable", () => {
+		printSummarizeResults([{ envName: "claude", status: "unavailable" }], "claude");
+		expect(logged()).toMatch(/not available/);
+	});
+
+	it("prints a per-env warning on error", () => {
+		printSummarizeResults([{ envName: "claude", status: "error", error: "boom" }], "claude");
+		const out = logged();
+		expect(out).toMatch(/Summary skipped for claude/);
+		expect(out).toContain("boom");
+	});
+
+	it("emits nothing for skipped-no-drift entries", () => {
+		printSummarizeResults([{ envName: "claude", status: "skipped-no-drift" }], "claude");
+		expect(logSpy.mock.calls.length).toBe(0);
 	});
 });

--- a/tests/core/merge/prompts.test.ts
+++ b/tests/core/merge/prompts.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildMergePrompt,
+	buildSummaryPrompt,
+	type SummaryDiffData,
+} from "../../../src/core/merge/prompts.js";
+
+describe("buildMergePrompt", () => {
+	it("includes all three sides and the relative path", () => {
+		const prompt = buildMergePrompt("CLAUDE.md", "base", "local", "remote", { kind: "markdown" });
+		expect(prompt).toContain("CLAUDE.md");
+		expect(prompt).toContain("<BASE>\nbase");
+		expect(prompt).toContain("<LOCAL>\nlocal");
+		expect(prompt).toContain("<REMOTE>\nremote");
+		expect(prompt).toContain("type: markdown");
+	});
+
+	it("handles null base as a 'no common ancestor' note", () => {
+		const prompt = buildMergePrompt("a.md", null, "L", "R", { kind: "markdown" });
+		expect(prompt).toContain("no common ancestor");
+	});
+});
+
+describe("buildSummaryPrompt", () => {
+	const sample: SummaryDiffData = {
+		localOnly: [{ relativePath: "CLAUDE.md", side: "local" }],
+		remoteOnly: [{ relativePath: "settings.json", side: "remote", snippet: "theme: dark" }],
+		bothChanged: [{ relativePath: "commands/foo.md", side: "both" }],
+	};
+
+	it("includes the env name in the preamble", () => {
+		const prompt = buildSummaryPrompt("claude", sample);
+		expect(prompt).toContain('"claude"');
+	});
+
+	it("lists files in their respective buckets", () => {
+		const prompt = buildSummaryPrompt("claude", sample);
+		expect(prompt).toMatch(/<LOCAL_ONLY>[\s\S]*CLAUDE\.md[\s\S]*<\/LOCAL_ONLY>/);
+		expect(prompt).toMatch(/<REMOTE_ONLY>[\s\S]*settings\.json[\s\S]*<\/REMOTE_ONLY>/);
+		expect(prompt).toMatch(/<BOTH_CHANGED>[\s\S]*commands\/foo\.md[\s\S]*<\/BOTH_CHANGED>/);
+	});
+
+	it("indents snippets under their file paths", () => {
+		const prompt = buildSummaryPrompt("claude", sample);
+		expect(prompt).toContain("    theme: dark");
+	});
+
+	it("renders empty buckets as (none)", () => {
+		const prompt = buildSummaryPrompt("opencode", {
+			localOnly: [],
+			remoteOnly: [],
+			bothChanged: [],
+		});
+		expect(prompt.match(/\(none\)/g)?.length).toBe(3);
+	});
+
+	it("asks for prose only, no merges", () => {
+		const prompt = buildSummaryPrompt("claude", sample);
+		expect(prompt.toLowerCase()).toContain("summary");
+		expect(prompt).toMatch(/Do not propose merges/);
+	});
+});

--- a/tests/core/merge/summarize.test.ts
+++ b/tests/core/merge/summarize.test.ts
@@ -1,0 +1,81 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ResolverError } from "../../../src/core/merge/resolver.js";
+import { summarizeWithResolver } from "../../../src/core/merge/summarize.js";
+
+let tmpRoot: string;
+beforeEach(async () => {
+	tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "ai-sync-summarize-test-"));
+});
+afterEach(async () => {
+	await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe("summarizeWithResolver", () => {
+	it("writes the prompt to a tempdir and shells out to the resolver CLI", async () => {
+		const execFn = vi.fn().mockResolvedValue({ stdout: "summary text", stderr: "" });
+		const out = await summarizeWithResolver("claude", "PROMPT", {
+			execFn,
+			tmpdirRoot: tmpRoot,
+		});
+		expect(out).toBe("summary text");
+		expect(execFn).toHaveBeenCalledOnce();
+		const [bin, args] = execFn.mock.calls[0];
+		expect(bin).toBe("claude");
+		expect(args[0]).toBe("-p");
+		const promptFile = args[1] as string;
+		// Tempdir is cleaned on success — file should NOT exist anymore.
+		await expect(fs.access(promptFile)).rejects.toBeDefined();
+	});
+
+	it("uses codex CLI flags for codex resolver", async () => {
+		const execFn = vi.fn().mockResolvedValue({ stdout: "ok", stderr: "" });
+		await summarizeWithResolver("codex", "P", { execFn, tmpdirRoot: tmpRoot });
+		const [bin, args] = execFn.mock.calls[0];
+		expect(bin).toBe("codex");
+		expect(args.slice(0, 2)).toEqual(["exec", "--prompt-file"]);
+	});
+
+	it("uses opencode CLI flags for opencode resolver", async () => {
+		const execFn = vi.fn().mockResolvedValue({ stdout: "ok", stderr: "" });
+		await summarizeWithResolver("opencode", "P", { execFn, tmpdirRoot: tmpRoot });
+		const [bin, args] = execFn.mock.calls[0];
+		expect(bin).toBe("opencode");
+		expect(args[0]).toBe("run");
+	});
+
+	it("throws ResolverError(non-zero-exit) when execFn rejects", async () => {
+		const execFn = vi.fn().mockRejectedValue(new Error("exit 1"));
+		await expect(
+			summarizeWithResolver("claude", "P", { execFn, tmpdirRoot: tmpRoot }),
+		).rejects.toBeInstanceOf(ResolverError);
+	});
+
+	it("throws ResolverError(malformed-output) when stdout is empty", async () => {
+		const execFn = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+		await expect(
+			summarizeWithResolver("claude", "P", { execFn, tmpdirRoot: tmpRoot }),
+		).rejects.toMatchObject({ reason: "malformed-output" });
+	});
+
+	it("throws ResolverError(timeout) when execFn aborts", async () => {
+		const execFn = vi.fn().mockImplementation((_b, _a, opts) => {
+			return new Promise((_resolve, reject) => {
+				opts?.signal?.addEventListener("abort", () => {
+					const err = new Error("aborted") as Error & { code: string };
+					err.code = "ABORT_ERR";
+					reject(err);
+				});
+			});
+		});
+		await expect(
+			summarizeWithResolver("claude", "P", {
+				execFn,
+				tmpdirRoot: tmpRoot,
+				timeoutMs: 10,
+			}),
+		).rejects.toMatchObject({ reason: "timeout" });
+	});
+});


### PR DESCRIPTION
Closes #30

## Summary

Adds opt-in `--summarize` flag to `ai-sync status`. When set, the configured AI resolver is invoked once per env-with-drift to produce a natural-language summary of what each side changed. Existing drift count output is preserved verbatim; summarize is purely additive.

## Behavior

- Reads `tools/merge-config.json` for the resolver name (default `claude`).
- Invokes the resolver exactly once per env with drift; envs with zero drift are silently skipped.
- If `adapter.available()` returns `false`, prints a yellow `Resolver '<name>' not available — install or change tools/merge-config.json` line and skips summarization. Exit code stays 0.
- If a resolver call throws, prints `Summary skipped for <env>: <reason>` in yellow and continues with the other envs.
- Diff payload is capped at 200 entries per env so the prompt never grows unbounded.
- New `buildSummaryPrompt(envName, diffData)` exported from `src/core/merge/prompts.ts`.
- New `summarizeWithResolver(name, prompt, options)` helper in `src/core/merge/summarize.ts` so the resolver CLI can be driven with a freeform prompt without going through MergeResolver.resolve().

## Test plan

- [x] `npm run typecheck`
- [x] `npm test -- tests/cli/commands/status.test.ts tests/core/merge/prompts.test.ts tests/core/merge/summarize.test.ts` (33 new/extended tests pass)
- [x] Full `npm test` — only failures are pre-existing flaky `tests/commands/link.test.ts` ENOTEMPTY rmdir races, unrelated to this change

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>