### PR TITLE
feat(merge): enable AI-merge by default + docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,14 +13,28 @@ npm run format         # Biome format
 npm run typecheck      # tsc --noEmit
 ```
 
+### CLI surface
+
+```bash
+ai-sync init | push | pull [--auto-apply] | status [--verbose] [--summarize]
+ai-sync bootstrap <repo-url> | update | install-skills | env | migrate
+ai-sync resolve list | diff <path> | accept <path|--all> | reject <path|--all>
+```
+
+AI-assisted merge is configured via `tools/merge-config.json` in the sync repo
+(see `docs/merge-config.md`). It is enabled by default; set `"enabled": false`
+to opt out.
+
 ## Architecture
 
 - `src/cli/` — Commander.js CLI entry point and commands
 - `src/core/` — Sync engine, manifest (allowlist), path rewriter, backups, environments
+- `src/core/merge/` — AI-assisted 3-way merge (config, adapters, strategies, staging, orchestrator)
 - `src/git/` — Git wrapper (simple-git)
 - `src/platform/` — Cross-platform path resolution
 - `tests/` — Mirrors src/ structure, uses Vitest + memfs
 - `skills/` — Slash command definitions (`.AGENTS.md` / `.opencode.md`)
+- `tools/merge-config.json` (in the sync repo, not this repo) — AI-merge config; schema in `src/core/merge/config.ts`
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,14 +13,28 @@ npm run format         # Biome format
 npm run typecheck      # tsc --noEmit
 ```
 
+### CLI surface
+
+```bash
+ai-sync init | push | pull [--auto-apply] | status [--verbose] [--summarize]
+ai-sync bootstrap <repo-url> | update | install-skills | env | migrate
+ai-sync resolve list | diff <path> | accept <path|--all> | reject <path|--all>
+```
+
+AI-assisted merge is configured via `tools/merge-config.json` in the sync repo
+(see `docs/merge-config.md`). It is enabled by default; set `"enabled": false`
+to opt out.
+
 ## Architecture
 
 - `src/cli/` — Commander.js CLI entry point and commands
 - `src/core/` — Sync engine, manifest (allowlist), path rewriter, backups, environments
+- `src/core/merge/` — AI-assisted 3-way merge (config, adapters, strategies, staging, orchestrator)
 - `src/git/` — Git wrapper (simple-git)
 - `src/platform/` — Cross-platform path resolution
 - `tests/` — Mirrors src/ structure, uses Vitest + memfs
 - `skills/` — Slash command definitions (`.claude.md` / `.opencode.md`)
+- `tools/merge-config.json` (in the sync repo, not this repo) — AI-merge config; schema in `src/core/merge/config.ts`
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -205,20 +205,40 @@ ai-sync push -v               # show detailed file changes
 
 ### `ai-sync pull`
 
-Fetches remote changes and applies them to local config directories. Always creates a timestamped backup first.
+Fetches remote changes and applies them to local config directories. Always
+creates a timestamped backup first. On 3-way merge conflicts, ai-sync uses the
+[AI-assisted merge](#ai-assisted-merge) flow.
 
 ```bash
 ai-sync pull
 ai-sync pull -v               # show detailed file changes
+ai-sync pull --auto-apply     # apply AI merges directly instead of staging them
 ```
 
 ### `ai-sync status`
 
-Shows local modifications, remote drift, and excluded file count.
+Shows local modifications, remote drift, and excluded file count. With
+`--summarize`, asks the configured AI resolver for a natural-language summary
+of the drift (see [AI-assisted merge](#ai-assisted-merge) below).
 
 ```bash
 ai-sync status
-ai-sync status -v             # include branch, tracking info, synced file count
+ai-sync status -v             # include branch, tracking info, synced file count, pending merges
+ai-sync status --summarize    # AI-generated summary of local/remote drift
+```
+
+### `ai-sync resolve`
+
+Manage pending AI merges produced by `ai-sync pull`. See
+[AI-assisted merge](#ai-assisted-merge) below.
+
+```bash
+ai-sync resolve list                # list pending merges
+ai-sync resolve diff <path>         # show the staged merge vs the live file
+ai-sync resolve accept <path>       # apply a staged merge
+ai-sync resolve accept --all        # apply every pending merge
+ai-sync resolve reject <path>       # discard a staged merge
+ai-sync resolve reject --all        # discard every pending merge
 ```
 
 ### `ai-sync bootstrap <repo-url>`
@@ -289,6 +309,62 @@ ai-sync --no-update-check <command>   # skip the auto-update check
 ai-sync --version                      # show version
 ai-sync --help                         # show help
 ```
+
+## AI-assisted merge
+
+When `ai-sync pull` finds that the same file was modified locally and remotely,
+it can ask a local AI CLI (`claude`, `codex`, or `opencode`) to produce a
+3-way merge instead of dropping back to keep-local. The feature is
+**enabled by default**.
+
+By default, merges are staged under `<syncRepoDir>/.ai-sync/pending/<env>/<path>`
+so you can review them with `ai-sync resolve` before applying. Set
+`autoApply: true` (or pass `ai-sync pull --auto-apply`) to skip staging.
+
+### Configuration: `tools/merge-config.json`
+
+Drop a `tools/merge-config.json` at the root of your sync repo to tune the
+behavior. All fields are optional.
+
+```jsonc
+{
+  "enabled": true,            // master switch — set to false to disable AI merge
+  "resolver": "claude",       // "claude" | "codex" | "opencode"
+  "autoApply": false,         // false = stage under .ai-sync/pending/, true = write through
+  "timeoutSeconds": 60,       // per-file resolver timeout
+  "perType": {
+    "*.md":   "ai-freeform",
+    "*.json": "ai-validated",
+    "*.yaml": "ai-validated",
+    "*.yml":  "ai-validated",
+    "*.lock": "keep-local",
+    "*":      "keep-local"
+  }
+}
+```
+
+To disable AI-merge entirely, write:
+
+```jsonc
+{ "enabled": false }
+```
+
+See [`docs/merge-config.md`](docs/merge-config.md) for the full schema reference.
+
+### Reviewing pending merges
+
+```bash
+ai-sync resolve list                # show pending merges
+ai-sync resolve diff <path>         # diff the staged merge against the live file
+ai-sync resolve accept <path>       # apply one staged merge
+ai-sync resolve accept --all        # apply all pending merges
+ai-sync resolve reject <path>       # discard one staged merge
+ai-sync resolve reject --all        # discard all pending merges
+```
+
+`ai-sync status --verbose` also lists pending merges, and
+`ai-sync status --summarize` asks the configured resolver for a natural-language
+description of what differs between local, remote, and base.
 
 ## Environments
 
@@ -470,7 +546,8 @@ src/
 │   ├── environment.ts        # Environment definitions (Claude, OpenCode)
 │   ├── env-config.ts         # Per-machine environment preferences
 │   ├── env-helpers.ts        # Shared helpers (allowlist, path rewrite checks)
-│   └── migration.ts          # v1→v2 repo migration
+│   ├── migration.ts          # v1→v2 repo migration
+│   └── merge/                # AI-assisted 3-way merge (adapters, strategies, staging)
 ├── git/
 │   └── repo.ts               # Git operations wrapper (simple-git)
 ├── platform/

--- a/docs/merge-config.md
+++ b/docs/merge-config.md
@@ -1,0 +1,83 @@
+# `tools/merge-config.json` reference
+
+ai-sync uses an opt-out, AI-assisted 3-way merge when pulling a v2 sync repo. The
+behavior is controlled by `tools/merge-config.json` at the root of the sync
+repo. If the file is absent, schema defaults apply.
+
+AI-assisted merge is **enabled by default**. To turn it off, write
+`{ "enabled": false }` into `tools/merge-config.json` and push.
+
+## Schema
+
+| Field            | Type                                    | Default       | Description                                                                                                                                |
+| ---------------- | --------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `enabled`        | `boolean`                               | `true`        | Master switch. When `false`, `ai-sync pull` falls back to the legacy keep-local behavior on conflict.                                      |
+| `resolver`       | `"claude" \| "codex" \| "opencode"`     | `"claude"`    | Which local CLI drives the merge prompt. The matching binary must be on `PATH`.                                                            |
+| `autoApply`      | `boolean`                               | `false`       | When `true`, merged content is written directly to the live config file. When `false`, merges land in `.ai-sync/pending/` for review.      |
+| `timeoutSeconds` | positive integer                        | `60`          | Per-file timeout for the resolver invocation. Hitting the timeout falls back to keep-local for that file.                                  |
+| `perType`        | record of glob → strategy               | (see below)   | Strategy override per glob. Strategies: `ai-freeform`, `ai-validated`, `keep-local`. Unmatched files use the `*` entry.                    |
+
+### `perType` defaults
+
+```jsonc
+{
+  "*.md":   "ai-freeform",   // free-form 3-way merge
+  "*.json": "ai-validated",  // 3-way merge + JSON.parse validation
+  "*.yaml": "ai-validated",
+  "*.yml":  "ai-validated",
+  "*.lock": "keep-local",    // never let AI touch lockfiles
+  "*":      "keep-local"     // safe default for unknown types
+}
+```
+
+## Examples
+
+### Disable AI-merge entirely
+
+```jsonc
+{
+  "enabled": false
+}
+```
+
+### Enable with auto-apply for Markdown only
+
+```jsonc
+{
+  "enabled": true,
+  "resolver": "claude",
+  "autoApply": true,
+  "timeoutSeconds": 90,
+  "perType": {
+    "*.md": "ai-freeform",
+    "*": "keep-local"
+  }
+}
+```
+
+### Use Codex as the resolver
+
+```jsonc
+{
+  "enabled": true,
+  "resolver": "codex"
+}
+```
+
+## How merges land
+
+- `autoApply: false` (default) — merged content is staged under
+  `<syncRepoDir>/.ai-sync/pending/<env>/<file>`. Use `ai-sync resolve list` to
+  see pending merges, `ai-sync resolve diff <path>` to inspect a single one,
+  and `ai-sync resolve accept <path>` / `ai-sync resolve reject <path>`
+  (or `--all`) to apply or discard them.
+- `autoApply: true` — merged content overwrites the live config file
+  immediately. The pre-pull backup under `~/.ai-sync-backups/<timestamp>/`
+  is your safety net.
+
+## Related commands
+
+- `ai-sync pull --auto-apply` — one-shot override of `autoApply` for a single pull.
+- `ai-sync status --verbose` — shows pending merges and resolver availability.
+- `ai-sync status --summarize` — asks the configured resolver for a natural-language drift summary.
+- `ai-sync resolve list | diff | accept | reject [--all]` — manage pending merges.

--- a/src/core/merge/config.ts
+++ b/src/core/merge/config.ts
@@ -5,11 +5,12 @@ import { z } from "zod";
 /**
  * Schema for `tools/merge-config.json` in the sync repo.
  *
- * `enabled` defaults to false in v1 — flipping the flag is its own issue.
- * When false, tryAiMerge short-circuits to fallback (keep-local).
+ * `enabled` defaults to true now that the AI-merge initiative is complete.
+ * When false, tryAiMerge short-circuits to fallback (keep-local). Set
+ * `"enabled": false` in `tools/merge-config.json` to disable AI-assisted merge.
  */
 export const MergeConfigSchema = z.object({
-	enabled: z.boolean().default(false),
+	enabled: z.boolean().default(true),
 	resolver: z.enum(["claude", "codex", "opencode"]).default("claude"),
 	autoApply: z.boolean().default(false),
 	timeoutSeconds: z.number().int().positive().default(60),

--- a/tests/core/merge/config.test.ts
+++ b/tests/core/merge/config.test.ts
@@ -17,7 +17,7 @@ afterEach(async () => {
 describe("loadMergeConfig()", () => {
 	it("returns schema defaults when the file is absent", async () => {
 		const cfg = await loadMergeConfig(syncRepoDir);
-		expect(cfg.enabled).toBe(false);
+		expect(cfg.enabled).toBe(true);
 		expect(cfg.resolver).toBe("claude");
 		expect(cfg.autoApply).toBe(false);
 		expect(cfg.timeoutSeconds).toBe(60);
@@ -68,7 +68,7 @@ describe("loadMergeConfig()", () => {
 describe("defaultMergeConfig()", () => {
 	it("returns the same defaults as the loader for an absent file", () => {
 		const cfg = defaultMergeConfig();
-		expect(cfg.enabled).toBe(false);
+		expect(cfg.enabled).toBe(true);
 		expect(cfg.resolver).toBe("claude");
 		expect(cfg.timeoutSeconds).toBe(60);
 	});

--- a/tests/core/merge/orchestrator.test.ts
+++ b/tests/core/merge/orchestrator.test.ts
@@ -47,7 +47,7 @@ describe("classifyFile()", () => {
 
 describe("tryAiMerge()", () => {
 	it("short-circuits to fallback when config.enabled is false", async () => {
-		const cfg = defaultMergeConfig();
+		const cfg = { ...defaultMergeConfig(), enabled: false };
 		expect(cfg.enabled).toBe(false);
 		let called = false;
 		const resolver: MergeResolver = {

--- a/tests/core/sync-engine.test.ts
+++ b/tests/core/sync-engine.test.ts
@@ -1170,6 +1170,15 @@ describe("core/sync-engine", () => {
 		it("detects 3-way merge conflict in v2 and keeps local", async () => {
 			const { bareDir, syncRepoDir, claudeConfigDir, options } = await createV2TestEnv(tmpDir);
 
+			// Explicitly disable AI merge so this test asserts the legacy
+			// keep-local behavior regardless of the schema default.
+			await fs.mkdir(path.join(syncRepoDir, "tools"), { recursive: true });
+			await fs.writeFile(
+				path.join(syncRepoDir, "tools", "merge-config.json"),
+				JSON.stringify({ enabled: false }),
+				"utf-8",
+			);
+
 			// Push initial
 			await syncPush(options);
 


### PR DESCRIPTION
Closes #31. Completes EPIC #23.

## Summary
- Flips `enabled` default in `src/core/merge/config.ts` from `false` to `true`, completing the AI-assisted merge rollout.
- Adds README section covering `ai-sync pull --auto-apply`, `ai-sync resolve list|diff|accept|reject [--all]`, `ai-sync status [--verbose] [--summarize]`, and the `tools/merge-config.json` config surface.
- Updates `CLAUDE.md` and `AGENTS.md` Commands/Architecture blocks; adds `docs/merge-config.md` as the JSON schema reference (resolver, autoApply, perType, timeoutSeconds, enabled).
- Updates tests: default-enabled assertion in `config.test.ts`, explicit opt-out in the orchestrator and v2-sync-engine conflict tests that asserted legacy keep-local behavior.

## Test plan
- [x] `npm test` — all green
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [ ] `npm run lint` — pre-existing failures on `main` unrelated to this change; warnings only on changed files