### PR TITLE
security: make startupUpdateCheck notify-only (don't auto-execute remote code)

### DIFF
--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -104,7 +104,8 @@ export async function performUpdate(force = false): Promise<UpdateResult> {
 /**
  * Silent startup check — runs on every CLI invocation but only
  * actually checks the remote once per CHECK_INTERVAL_MS.
- * Auto-updates if a new version is found.
+ * Only notifies the user that an update is available; does NOT
+ * auto-execute any code. The user must run `ai-sync update` explicitly.
  * Never throws — any error is silently swallowed.
  */
 export async function startupUpdateCheck(): Promise<string | null> {
@@ -132,31 +133,9 @@ export async function startupUpdateCheck(): Promise<string | null> {
 
 		if (localHead === remoteHead) return null;
 
-		const fromRef = localHead.slice(0, 7);
-
-		execSync("git reset --hard origin/main", {
-			cwd: installDir,
-			stdio: "pipe",
-		});
-
-		execSync("npm install --no-fund --no-audit --loglevel=error", {
-			cwd: installDir,
-			stdio: "pipe",
-			timeout: INSTALL_TIMEOUT_MS,
-		});
-
-		execSync("npm run build --silent", {
-			cwd: installDir,
-			stdio: "pipe",
-			timeout: BUILD_TIMEOUT_MS,
-		});
-
-		const toRef = execSync("git rev-parse --short HEAD", {
-			cwd: installDir,
-			encoding: "utf-8",
-		}).trim();
-
-		return `ai-sync updated: ${fromRef} → ${toRef}`;
+		// Notify only — do not auto-execute remote code.
+		// The user must run `ai-sync update` to apply the update.
+		return `ai-sync update available (${localHead.slice(0, 7)} → ${remoteHead.slice(0, 7)}). Run: ai-sync update`;
 	} catch {
 		return null; // silent failure
 	}

--- a/tests/core/updater.test.ts
+++ b/tests/core/updater.test.ts
@@ -215,19 +215,13 @@ describe("core/updater", () => {
 			mockedExecSync.mockImplementationOnce(() => "aaaaaaa1234567890ab\n");
 			// Mock git rev-parse origin/main (remote) — different
 			mockedExecSync.mockImplementationOnce(() => "bbbbbbb9876543210cd\n");
-			// Mock git reset --hard
-			mockedExecSync.mockImplementationOnce(() => Buffer.from(""));
-			// Mock npm install
-			mockedExecSync.mockImplementationOnce(() => Buffer.from(""));
-			// Mock npm run build
-			mockedExecSync.mockImplementationOnce(() => Buffer.from(""));
-			// Mock git rev-parse --short HEAD
-			mockedExecSync.mockImplementationOnce(() => "bbbbbbb\n");
 
+			// startupUpdateCheck is notify-only by design (it must not execute
+			// remote code unprompted); the user runs `ai-sync update` to apply.
 			const result = await startupUpdateCheck();
 
 			expect(result).not.toBeNull();
-			expect(result).toContain("ai-sync updated");
+			expect(result).toContain("ai-sync update available");
 			expect(result).toContain("aaaaaaa");
 			expect(result).toContain("bbbbbbb");
 		});


### PR DESCRIPTION
## The problem
`startupUpdateCheck()` runs on **every CLI invocation** and, when the remote is ahead, currently **auto-executes remote code**:
```
git reset --hard origin/main
npm install …
npm run build …
```
This means **any commit pushed to upstream `main` runs automatically on every user's machine** the next time they invoke ai-sync — before they've seen it. That's a supply-chain / RCE exposure: a compromised maintainer account, a malicious PR that slips through, or even an honest bad commit gets executed everywhere, silently, with the user's privileges. A config-sync tool that self-mutates from the network on every run is a high-value target.

## The change
Make the startup check **notify-only**. It now returns:
> `ai-sync update available (abc1234 → def5678). Run: ai-sync update`

…and the user applies the update **explicitly**. The existing `performUpdate()` (the `ai-sync update` command) is **unchanged** — manual updates work exactly as before. This is the standard, safe pattern (npm, gh, brew, etc. all *notify* rather than auto-run on startup).

## Scope
- One function, `src/core/updater.ts` (+8 / −35). No new deps, no API changes.
- All existing updater + update-command tests pass (20 tests); the startup-check test now asserts the notify message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)