### PR TITLE
fix(bootstrap): don't run an SSH connectivity check for HTTPS repo URLs

### DIFF
--- a/src/cli/commands/bootstrap.ts
+++ b/src/cli/commands/bootstrap.ts
@@ -18,15 +18,23 @@ import { isGitRepo } from "../../git/repo.js";
 import { getClaudeDir, getSyncRepoDir } from "../../platform/paths.js";
 
 /**
+ * Extracts the host from an SSH-style git URL (ssh://, scp-style git@host:path,
+ * or any user@host:path). Returns null for HTTP(S) URLs and anything that
+ * isn't recognizably SSH. Exported for unit testing.
+ */
+export function parseSshHost(repoUrl: string): string | null {
+	if (repoUrl.startsWith("http://") || repoUrl.startsWith("https://")) return null;
+	const sshMatch = repoUrl.match(/^(?:ssh:\/\/)?(?:[^@\s]+@)([^:/\s]+)/);
+	return sshMatch?.[1] ?? null;
+}
+
+/**
  * Checks SSH connectivity to the host in the given URL.
- * Returns null on success, or an error message string on failure.
+ * Returns null on success (or when the URL isn't SSH), or an error message string on failure.
  */
 function checkSshConnectivity(repoUrl: string): string | null {
-	// Only check for SSH-style URLs
-	const sshMatch = repoUrl.match(/^(?:ssh:\/\/)?(?:[^@]+@)?([^:/]+)/);
-	if (!sshMatch && !repoUrl.includes("git@")) return null;
-
-	const host = sshMatch?.[1] ?? "github.com";
+	const host = parseSshHost(repoUrl);
+	if (host === null) return null;
 
 	// Validate hostname to prevent command injection — only allow DNS-safe characters
 	if (!/^[a-zA-Z0-9._-]+$/.test(host)) {

--- a/tests/commands/bootstrap.test.ts
+++ b/tests/commands/bootstrap.test.ts
@@ -4,7 +4,11 @@ import * as path from "node:path";
 import { Command } from "commander";
 import { simpleGit } from "simple-git";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { handleBootstrap, registerBootstrapCommand } from "../../src/cli/commands/bootstrap.js";
+import {
+	handleBootstrap,
+	parseSshHost,
+	registerBootstrapCommand,
+} from "../../src/cli/commands/bootstrap.js";
 import { isGitRepo } from "../../src/git/repo.js";
 
 /**
@@ -368,5 +372,33 @@ describe("bootstrap CLI action (integration)", () => {
 		const errOutput = errorSpy.mock.calls.map((c) => c[0]).join("\n");
 		expect(errOutput).toContain("Bootstrap failed");
 		expect(process.exitCode).toBe(1);
+	});
+});
+
+describe("parseSshHost", () => {
+	it("returns null for https URLs (regression: bootstrap previously misparsed 'https' as host)", () => {
+		expect(parseSshHost("https://github.com/foo/bar.git")).toBeNull();
+	});
+
+	it("returns null for http URLs", () => {
+		expect(parseSshHost("http://example.com/foo/bar.git")).toBeNull();
+	});
+
+	it("extracts host from scp-style git@github.com:owner/repo.git", () => {
+		expect(parseSshHost("git@github.com:owner/repo.git")).toBe("github.com");
+	});
+
+	it("extracts host from ssh:// URL with user", () => {
+		expect(parseSshHost("ssh://git@github.com/owner/repo.git")).toBe("github.com");
+	});
+
+	it("extracts host from a non-github SSH URL", () => {
+		expect(parseSshHost("user@gitlab.example.com:proj/repo.git")).toBe("gitlab.example.com");
+	});
+
+	it("returns null for local paths (no user@host)", () => {
+		expect(parseSshHost("/some/local/path")).toBeNull();
+		expect(parseSshHost("./relative/path")).toBeNull();
+		expect(parseSshHost("file:///tmp/repo")).toBeNull();
 	});
 });


### PR DESCRIPTION
## Problem
`handleBootstrap` runs an SSH preflight (`ssh -T <host>`) before cloning. For **HTTPS** repo URLs (`https://github.com/…`) this is wrong: the clone uses HTTPS, not SSH, so a user who clones over HTTPS (or has no SSH key) gets a spurious SSH failure and bootstrap aborts even though the HTTPS clone would have worked.

## Fix
Only run the SSH check for SSH-style URLs (`git@…` / `ssh://…`); skip it for HTTPS. Verified by the bootstrap test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)