### PR TITLE
fix: Windows support (silent CLI exit + git add ENAMETOOLONG)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -79,12 +79,14 @@ export { program };
 
 // Only parse when run directly (not imported as a module)
 // Check if this file is the entry point
+// ponytail: normalize Windows backslashes so the entry-point check works cross-platform
+const entry = process.argv[1]?.replace(/\\/g, "/");
 const isDirectRun =
 	typeof process !== "undefined" &&
-	process.argv[1] &&
-	(process.argv[1].endsWith("/cli/index.ts") ||
-		process.argv[1].endsWith("/cli.js") ||
-		process.argv[1].endsWith("/ai-sync"));
+	entry &&
+	(entry.endsWith("/cli/index.ts") ||
+		entry.endsWith("/cli.js") ||
+		entry.endsWith("/ai-sync"));
 
 if (isDirectRun) {
 	// Run startup update check before parsing commands

--- a/src/git/repo.ts
+++ b/src/git/repo.ts
@@ -45,7 +45,11 @@ export async function isGitRepo(dirPath: string): Promise<boolean> {
  * @param files - Array of relative file paths to stage
  */
 export async function addFiles(repoPath: string, files: string[]): Promise<void> {
-	await simpleGit(repoPath).add(files);
+	// ponytail: batch to stay under the Windows ~32K command-line limit (ENAMETOOLONG with many skills)
+	const git = simpleGit(repoPath);
+	for (let i = 0; i < files.length; i += 100) {
+		await git.add(files.slice(i, i + 100));
+	}
 }
 
 /**


### PR DESCRIPTION
Two bugs prevent ai-sync from working on native Windows (no WSL). Both are small, platform-only fixes.

## 1. CLI exits silently on Windows
`src/cli/index.ts` decides whether to parse argv by checking `process.argv[1].endsWith("/cli.js")` (and `/cli/index.ts`, `/ai-sync`) — forward slashes only. On Windows `process.argv[1]` is `...\dist\cli.js`, so `isDirectRun` is `false`, the program never parses, and **every command exits 0 printing nothing** (including `--version`/`--help`).

Fix: normalize `\` → `/` before the suffix checks.

## 2. `init`/`push` fail with `spawn ENAMETOOLONG`
`src/git/repo.ts` `addFiles` passes every staged path to a single `git add`. With a real `~/.claude` (many skills/plugins → thousands of files) the argument list exceeds Windows' ~32K command-line limit and `git` fails to spawn. The existing comment says staging must stay explicit (never `git add .`), so this batches the same explicit paths instead of switching to `-A`.

Fix: stage in chunks of 100.

## Testing
On Windows 10 (native, Node 25, git 2.54): before, all commands were silent; after, `ai-sync init` synced 2675 files and `push`/`pull`/`status`/`bootstrap` work end-to-end against a private GitHub config repo. No behavior change on POSIX (backslash normalization is a no-op there; chunking produces identical staging).